### PR TITLE
feat: Clear canvas button + confirm dialog

### DIFF
--- a/packages/web/src/components/ClearCanvasDialog.test.tsx
+++ b/packages/web/src/components/ClearCanvasDialog.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ClearCanvasDialog } from "./ClearCanvasDialog";
+
+const base = { counts: { marts: 3, relationships: 2 } };
+
+describe("ClearCanvasDialog", () => {
+  it("warns it's permanent and shows the counts", () => {
+    render(<ClearCanvasDialog {...base} onDelete={() => {}} onExportAndDelete={() => {}} onClose={() => {}} />);
+    expect(screen.getByText(/permanently deletes everything/i)).toBeTruthy();
+    expect(screen.getByText(/can't be undone/i)).toBeTruthy();
+    expect(screen.getByText("3 marts")).toBeTruthy();
+    expect(screen.getByText("2 relationships")).toBeTruthy();
+  });
+
+  it("singularises the counts", () => {
+    render(<ClearCanvasDialog counts={{ marts: 1, relationships: 1 }} onDelete={() => {}} onExportAndDelete={() => {}} onClose={() => {}} />);
+    expect(screen.getByText("1 mart")).toBeTruthy();
+    expect(screen.getByText("1 relationship")).toBeTruthy();
+  });
+
+  it("wires Delete, Export OKF & delete and Cancel", () => {
+    const onDelete = vi.fn(), onExportAndDelete = vi.fn(), onClose = vi.fn();
+    render(<ClearCanvasDialog {...base} onDelete={onDelete} onExportAndDelete={onExportAndDelete} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /export okf & delete/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onExportAndDelete).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when clicking the backdrop", () => {
+    const onClose = vi.fn();
+    const { container } = render(<ClearCanvasDialog {...base} onDelete={() => {}} onExportAndDelete={() => {}} onClose={onClose} />);
+    fireEvent.click(container.firstChild as Element);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/ClearCanvasDialog.tsx
+++ b/packages/web/src/components/ClearCanvasDialog.tsx
@@ -1,0 +1,62 @@
+interface ClearCanvasDialogProps {
+  counts: { marts: number; relationships: number };
+  onDelete: () => void;           // wipe the canvas, no export
+  onExportAndDelete: () => void;  // download an OKF bundle, then wipe
+  onClose: () => void;            // cancel
+}
+
+// Destructive-action confirmation before clearing the whole canvas. Clearing is
+// permanent and can't be undone, so we nudge the user to export an OKF bundle
+// to their computer first. Two destructive paths (export-then-delete, or just
+// delete) plus Cancel.
+export function ClearCanvasDialog({ counts, onDelete, onExportAndDelete, onClose }: ClearCanvasDialogProps) {
+  const empty = counts.marts === 0 && counts.relationships === 0;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-xl shadow-xl w-[460px] max-w-[95vw] p-6 flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-[15px] font-semibold text-slate-900">Clear canvas</h2>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-700 text-xl leading-none px-1">✕</button>
+        </div>
+
+        <div className="rounded-lg border border-[#f4caca] bg-[#fdf2f2] px-4 py-3 text-[13px] leading-relaxed text-[#7f1d1d]">
+          This permanently deletes everything on the canvas
+          {!empty && (
+            <> — <span className="font-semibold">{counts.marts} {counts.marts === 1 ? "mart" : "marts"}</span> and <span className="font-semibold">{counts.relationships} {counts.relationships === 1 ? "relationship" : "relationships"}</span></>
+          )}
+          . This can&apos;t be undone.
+        </div>
+
+        <p className="text-[13px] text-slate-600">
+          We recommend exporting an <span className="font-semibold">OKF</span> bundle to your computer first so you can re-import this model later.
+        </p>
+
+        <div className="flex items-center justify-between gap-2">
+          <button
+            onClick={onClose}
+            className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-4 py-[7px] cursor-pointer hover:bg-[#f1f3f7]"
+          >
+            Cancel
+          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={onExportAndDelete}
+              className="text-[13px] font-[550] border border-[#dc2626] bg-white text-[#dc2626] rounded-lg px-4 py-[7px] cursor-pointer hover:bg-[#fdf2f2]"
+            >
+              Export OKF &amp; delete
+            </button>
+            <button
+              onClick={onDelete}
+              className="text-[13px] font-[550] bg-[#dc2626] text-white border border-[#dc2626] rounded-lg px-4 py-[7px] cursor-pointer hover:bg-[#b91c1c]"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -44,6 +44,7 @@ import { TemplateApplyDialog } from "../TemplateApplyDialog";
 import { WelcomeDialog } from "../WelcomeDialog";
 import { SignInModal } from "../SignInModal";
 import { PushConfirmDialog } from "../PushConfirmDialog";
+import { ClearCanvasDialog } from "../ClearCanvasDialog";
 import { pushIntent } from "../../sync/pushGate";
 import { reconcileStorageId } from "../../sync/storageReconcile";
 import { Dock, type Tool } from "./Dock";
@@ -183,6 +184,7 @@ function CanvasInner() {
   const [storages, setStorages] = useState<StorageOption[]>([]);
   const [signIn, setSignIn] = useState<{ mode: "connect" | "push" } | null>(null);
   const [showPushConfirm, setShowPushConfirm] = useState(false);
+  const [showClear, setShowClear] = useState(false);
   const { me, connect, signOut } = useAuth();
 
   // Load the project's storages once signed in; retry through OWOX's transient
@@ -370,6 +372,19 @@ function CanvasInner() {
     const files = graphToBundleFiles(store.get(), title);
     downloadBundle(files, title);
   }, [me]);
+
+  // Clear the canvas: permanently wipe every node + edge (keep the selected
+  // storage). No undo — the dialog warns and offers an OKF export first.
+  const clearCanvas = useCallback(() => {
+    store.set({ storageId: store.get().storageId, nodes: [], edges: [] });
+    setSelection(null);
+    setShowClear(false);
+  }, []);
+
+  const handleExportAndClear = useCallback(() => {
+    handleExport();
+    clearCanvas();
+  }, [handleExport, clearCanvas]);
 
   // Export the canvas as an SVG (whole model, OWOX watermark). Uses the live RF
   // node list (measured sizes) to frame the export.
@@ -564,6 +579,14 @@ function CanvasInner() {
           onClose={() => setShowPushConfirm(false)}
         />
       )}
+      {showClear && (
+        <ClearCanvasDialog
+          counts={{ marts: graph.nodes.length, relationships: graph.edges.length }}
+          onDelete={clearCanvas}
+          onExportAndDelete={handleExportAndClear}
+          onClose={() => setShowClear(false)}
+        />
+      )}
       {showWelcome && (
         <WelcomeDialog
           onUseTemplate={(g, name) => { handleUseTemplate(g, name); setShowWelcome(false); }}
@@ -616,7 +639,7 @@ function CanvasInner() {
 
       <div className="flex flex-1 min-h-0 relative">
         {/* Left tool dock */}
-        <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} />
+        <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} onClear={() => setShowClear(true)} clearDisabled={graph.nodes.length === 0} />
 
         {/* React Flow canvas */}
         <div

--- a/packages/web/src/components/canvas/Dock.test.tsx
+++ b/packages/web/src/components/canvas/Dock.test.tsx
@@ -6,7 +6,7 @@ describe("Dock ERD toggle", () => {
   it("renders the ERD toggle and fires onToggleView when clicked", () => {
     const onToggleView = vi.fn();
     render(
-      <Dock activeTool="select" onToolChange={() => {}} viewMode="compact" onToggleView={onToggleView} />,
+      <Dock activeTool="select" onToolChange={() => {}} viewMode="compact" onToggleView={onToggleView} onClear={() => {}} />,
     );
     const toggle = screen.getByRole("button", { name: /ERD view/i });
     fireEvent.click(toggle);
@@ -15,8 +15,17 @@ describe("Dock ERD toggle", () => {
 
   it("reflects the active ERD state via aria-pressed", () => {
     render(
-      <Dock activeTool="select" onToolChange={() => {}} viewMode="erd" onToggleView={() => {}} />,
+      <Dock activeTool="select" onToolChange={() => {}} viewMode="erd" onToggleView={() => {}} onClear={() => {}} />,
     );
     expect(screen.getByRole("button", { name: /ERD view/i }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("fires onClear when the Clear canvas button is clicked", () => {
+    const onClear = vi.fn();
+    render(
+      <Dock activeTool="select" onToolChange={() => {}} viewMode="compact" onToggleView={() => {}} onClear={onClear} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Clear canvas/i }));
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/components/canvas/Dock.tsx
+++ b/packages/web/src/components/canvas/Dock.tsx
@@ -8,6 +8,8 @@ interface DockProps {
   onToolChange: (tool: Tool) => void;
   viewMode: ViewMode;
   onToggleView: () => void;
+  onClear: () => void;
+  clearDisabled?: boolean;
 }
 
 const SelectIcon = () => (
@@ -45,6 +47,15 @@ const ErdIcon = () => (
     <rect x="3" y="4" width="8" height="16" rx="1" />
     <rect x="14" y="4" width="7" height="9" rx="1" />
     <path d="M11 8h3M7 9v6M17 13v3M17 16h-6" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" width={19} height={19}>
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6M14 11v6" />
   </svg>
 );
 
@@ -86,7 +97,7 @@ function ToolButton({ icon, tip, active, onClick }: ToolButtonProps) {
   );
 }
 
-export function Dock({ activeTool, onToolChange, viewMode, onToggleView }: DockProps) {
+export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear, clearDisabled }: DockProps) {
   // Keyboard shortcuts V/N/C
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -102,7 +113,7 @@ export function Dock({ activeTool, onToolChange, viewMode, onToggleView }: DockP
 
   return (
     <div
-      className="absolute left-[14px] top-1/2 -translate-y-1/2 bg-white border border-[#d8dee8] rounded-xl p-[6px] flex flex-col gap-1 z-20 shadow-[0_4px_16px_rgba(15,23,42,0.06)]"
+      className="absolute left-[14px] top-[calc(50%-34px)] -translate-y-1/2 bg-white border border-[#d8dee8] rounded-xl p-[6px] flex flex-col gap-1 z-20 shadow-[0_4px_16px_rgba(15,23,42,0.06)]"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif" }}
     >
       <ToolButton
@@ -147,6 +158,24 @@ export function Dock({ activeTool, onToolChange, viewMode, onToggleView }: DockP
           <ErdIcon />
         </button>
         <DockTip label={viewMode === "erd" ? "ERD view — fields & field-level links (on)" : "ERD view — show fields & field-level links"} />
+      </div>
+      <div className="h-px bg-[#d8dee8] mx-1 my-[3px]" />
+      <div className="relative group">
+        <button
+          onClick={onClear}
+          disabled={clearDisabled}
+          aria-label="Clear canvas — delete everything"
+          className={`
+            w-[38px] h-[38px] rounded-[9px] border-none flex items-center justify-center transition-colors
+            ${clearDisabled
+              ? "bg-transparent text-slate-300 cursor-not-allowed"
+              : "bg-transparent text-slate-500 cursor-pointer hover:bg-[#fdf2f2] hover:text-[#dc2626]"
+            }
+          `}
+        >
+          <TrashIcon />
+        </button>
+        <DockTip label={clearDisabled ? "Clear canvas — nothing to clear" : "Clear canvas — delete everything"} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Adds a **Clear canvas** action to the left tool Dock.

- New trash-can icon button at the bottom of the Dock (dock nudged up slightly to fit).
- Opens `ClearCanvasDialog`: warns the wipe is **permanent / no undo**, recommends exporting an OKF bundle first, and offers three paths:
  - **Delete** (solid red) — wipe now.
  - **Export OKF & delete** (red outline) — download the `.zip` bundle, then wipe.
  - **Cancel**.
- Button is **disabled when the canvas is empty**.

## Behaviour

Clearing resets nodes + edges (keeps the selected storage) and clears the current selection. The change persists through the existing `persistGraph` localStorage mirror.

## Verification

- `tsc --noEmit` clean
- 169 web tests pass (added a Dock test for the Clear button)
- `pnpm --filter @mc/web build` clean
- Verified live on the local dev server (icon, disabled state, dialog, both delete paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)