### PR TITLE
feat(web): open a template via ?template=<id> deep-link

### DIFF
--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -29,6 +29,7 @@ import type { ModelNode, ModelEdge, ModelGraph } from "@mc/okf";
 
 import { graphToBundleFiles, downloadBundle } from "../../okf/io";
 import { buildShareUrl, readSharedModel, clearSharedModelFromUrl } from "../../share/url";
+import { readTemplateModel, clearTemplateFromUrl } from "../../lib/templateLink";
 import { exportCanvasSvg } from "../../share/exportImage";
 import { pushModel, pushPreview, type PushResult } from "../../sync/push";
 import { detachFromOwox } from "../../sync/detach";
@@ -60,26 +61,39 @@ import { loadGoal, persistGoal, type BusinessGoal } from "../../state/goal";
 const ReactFlow = ReactFlowBase as unknown as FC<ReactFlowProps>;
 
 // ── store singleton (exported so external modules can share this instance) ───
-// A shared link (#m=…) wins over localStorage: opening it reopens that exact
-// model. Otherwise rehydrate from localStorage so a refresh doesn't wipe work.
-const sharedGraph = readSharedModel();
-const persistedGraph = loadPersistedGraph();
-export const store = createModelStore(sharedGraph ?? persistedGraph);
-if (sharedGraph) {
-  // Persist the opened model right away — it's the store's initial value, so it
-  // never fires a change that the mirror-to-localStorage effect would catch; a
-  // refresh would otherwise lose it once the hash is cleared.
-  persistGraph(store.get());
-  // Drop the payload from the address bar so a refresh doesn't re-clobber the
-  // canvas and the URL stays clean.
-  clearSharedModelFromUrl();
+// Precedence: a `?template=<id>` deep-link and a `#m=…` share link are both
+// explicit "open this model" intents, so they win over localStorage; otherwise
+// rehydrate from localStorage so a refresh doesn't wipe work.
+//
+// `?template=<id>` opens a named built-in template (the CTA target for the blog
+// gallery, launch emails and posts). Templates ship at (0,0), so we Dagre-lay it
+// out here — runDagreLayout is a hoisted function declaration, available now.
+const templateGraph = readTemplateModel();
+clearTemplateFromUrl(); // strip the param (clean URL on refresh) even if the id was unknown
+let templateInitial: ModelGraph | undefined;
+if (templateGraph) {
+  const positions = runDagreLayout(templateGraph.nodes, templateGraph.edges, loadViewMode());
+  templateInitial = { ...templateGraph, nodes: templateGraph.nodes.map(n => ({ ...n, position: positions.get(n.key) ?? n.position })) };
 }
 
-// A truly first-ever visit has no persisted model and no shared link. Captured at
-// module load — before the persist effect writes an (empty) graph — so it stays
-// true for the session. Gates the first-screen "start" chooser: shown once for
-// new visitors, never over a returning user's model or an opened shared link.
-const isFirstVisit = !sharedGraph && persistedGraph === undefined;
+const sharedGraph = readSharedModel();
+const persistedGraph = loadPersistedGraph();
+export const store = createModelStore(templateInitial ?? sharedGraph ?? persistedGraph);
+if (templateInitial || sharedGraph) {
+  // Persist the opened model right away — it's the store's initial value, so it
+  // never fires a change that the mirror-to-localStorage effect would catch; a
+  // refresh would otherwise lose it once the URL is cleaned.
+  persistGraph(store.get());
+}
+// Drop the share payload from the address bar so a refresh doesn't re-clobber the
+// canvas and the URL stays clean (the template param is already cleared above).
+if (sharedGraph) clearSharedModelFromUrl();
+
+// A truly first-ever visit has no template deep-link, no persisted model and no
+// shared link. Captured at module load — before the persist effect writes an
+// (empty) graph — so it stays true for the session. Gates the first-screen
+// "start" chooser: shown once for new visitors, never over an opened model.
+const isFirstVisit = !templateInitial && !sharedGraph && persistedGraph === undefined;
 
 // Map a loaded template (by its display name) to the closest Insight-Questions
 // niche, so opening the Business Goal dialog after a template can pre-pick it.

--- a/packages/web/src/lib/templateLink.test.ts
+++ b/packages/web/src/lib/templateLink.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readTemplateModel, clearTemplateFromUrl } from "./templateLink";
+
+const setUrl = (url: string) => history.replaceState(null, "", url);
+
+beforeEach(() => setUrl("/"));
+
+describe("readTemplateModel", () => {
+  it("loads a known template by id", () => {
+    setUrl("/?template=ecommerce");
+    const g = readTemplateModel();
+    expect(g).not.toBeNull();
+    expect(g!.nodes.some(n => n.key === "dim_customer")).toBe(true);
+    expect(g!.edges.length).toBeGreaterThan(0);
+  });
+
+  it("returns a fresh deep clone each call (the source template is never mutated)", () => {
+    setUrl("/?template=ecommerce");
+    const a = readTemplateModel()!;
+    a.nodes[0].title = "MUTATED";
+    const b = readTemplateModel()!;
+    expect(b.nodes[0].title).not.toBe("MUTATED");
+  });
+
+  it("returns null for an unknown id", () => {
+    setUrl("/?template=does-not-exist");
+    expect(readTemplateModel()).toBeNull();
+  });
+
+  it("returns null when no template param is present", () => {
+    setUrl("/?utm_source=newsletter");
+    expect(readTemplateModel()).toBeNull();
+  });
+});
+
+describe("clearTemplateFromUrl", () => {
+  it("removes only the template param, preserving UTM params and the hash", () => {
+    setUrl("/?template=saas&utm_source=newsletter#m=abc");
+    clearTemplateFromUrl();
+    expect(location.search).toBe("?utm_source=newsletter");
+    expect(location.hash).toBe("#m=abc");
+  });
+
+  it("is a no-op when there is no template param", () => {
+    setUrl("/?utm_source=x");
+    clearTemplateFromUrl();
+    expect(location.search).toBe("?utm_source=x");
+  });
+});

--- a/packages/web/src/lib/templateLink.ts
+++ b/packages/web/src/lib/templateLink.ts
@@ -1,0 +1,32 @@
+import type { ModelGraph } from "@mc/okf";
+import { TEMPLATES } from "../templates";
+
+// Deep-link: `model.owox.com/?template=<id>` opens a named built-in template
+// straight onto the canvas. It's the CTA target for the blog template gallery,
+// launch emails and social posts — one click from "here's a model" to "you're
+// editing it". An unknown/missing id falls through to the normal first-run flow.
+
+const PARAM = "template";
+
+/** If the URL carries `?template=<id>` and it matches a known template, return a
+ *  deep clone of that template's graph. Positions are still (0,0) — the caller
+ *  runs Dagre layout, exactly like any freshly loaded model. Missing or unknown
+ *  id → null (so the bootstrap falls back to shared link / localStorage / welcome). */
+export function readTemplateModel(): ModelGraph | null {
+  const id = new URLSearchParams(location.search).get(PARAM);
+  if (!id) return null;
+  const t = TEMPLATES.find(tpl => tpl.id === id);
+  return t ? structuredClone(t.graph) : null;
+}
+
+/** Strip the `template` param from the address bar after loading, so a refresh
+ *  doesn't re-clobber the canvas. UTM params and the hash are preserved — the
+ *  UTMs are captured by analytics at page load, and the hash may carry a share
+ *  link. Safe to call unconditionally: no-ops when the param isn't present. */
+export function clearTemplateFromUrl(): void {
+  const params = new URLSearchParams(location.search);
+  if (!params.has(PARAM)) return;
+  params.delete(PARAM);
+  const qs = params.toString();
+  history.replaceState(null, "", location.pathname + (qs ? `?${qs}` : "") + location.hash);
+}


### PR DESCRIPTION
## What
`model.owox.com/?template=<id>` now opens a named built-in template straight onto the canvas, Dagre-laid-out, and then strips the param from the URL.

This is the **CTA target** for the blog template gallery, launch emails, and social posts — one click from "here's a model" to "you're editing it". Without it, those links can only drop people on a blank canvas.

## How it behaves
- **`lib/templateLink.ts`** — `readTemplateModel()` resolves `?template=<id>` against the `TEMPLATES` registry (deep clone; unknown/missing id → `null`, so we fall through gracefully). `clearTemplateFromUrl()` strips **only** the `template` param, preserving UTMs (analytics is captured at page load) and any `#m=` share hash.
- **Canvas bootstrap** — a template deep-link is an explicit "open this" intent, so it **wins over `localStorage`** (mirroring how a `#m=` share link already wins), is **auto-laid-out** via the existing `runDagreLayout`, and **skips the first-visit welcome chooser**.
- Valid ids: `ecommerce, saas, marketplace, marketing_ads, mobile_gaming, finance, medical, crypto_bitcoin, stackoverflow`.

## Testing
- New unit tests: `lib/templateLink.test.ts` (6) — known id, deep-clone isolation, unknown id, no-param, param-stripping (keeps UTM + hash), no-op clear.
- Full web suite green: **179/179** passing; `tsc --noEmit` clean.
- Browser-verified: loading `/?template=ecommerce` renders all 6 marts laid out (not piled at 0,0), URL cleaned to `/`, no console errors.

## Notes
- Scope is `packages/web` only; no server/API changes.
- Deliberate choice: the deep-link replaces an existing local model (same precedence as share links). Open to gating behind a Replace/Merge prompt if you'd prefer — but the link's whole purpose is "show me this template".