### PR TITLE
feat(web): sign up to save models (Supabase, anonymous-first)

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -33,7 +33,10 @@ export function buildApp() {
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", "data:", "blob:"],
         fontSrc: ["'self'", "data:"],
-        connectSrc: ["'self'", POSTHOG_PROXY],
+        // Supabase ("sign up to save"): the browser talks to the project's Auth +
+        // REST API directly. Wildcard covers any project (dev/prod) without baking
+        // the ref into the CSP; wss for the (currently unused) realtime channel.
+        connectSrc: ["'self'", POSTHOG_PROXY, "https://*.supabase.co", "wss://*.supabase.co"],
         workerSrc: ["'self'", "blob:"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,0 +1,6 @@
+# Supabase — "sign up to save your models". These are PUBLIC client-side values
+# (Row-Level Security is the security boundary, not the key). Leave them unset to
+# disable the feature entirely — the anonymous canvas is unaffected. Get them from
+# your Supabase project -> Project Settings -> API.
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.1.0",
     "@mc/okf": "workspace:*",
+    "@supabase/supabase-js": "^2.108.2",
     "@xyflow/react": "^12.3.0",
     "fflate": "^0.8.3",
     "html-to-image": "^1.11.13",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider, useAuth } from "./lib/auth";
+import { AccountProvider } from "./lib/account";
 import { CanvasApp } from "./components/canvas/Canvas";
 
 function Shell() {
@@ -8,9 +9,13 @@ function Shell() {
 }
 
 export function App() {
+  // AuthProvider = OWOX "connect" (Push). AccountProvider = Supabase account
+  // (Save). Independent; the account UI manages its own readiness.
   return (
-    <AuthProvider>
-      <Shell />
-    </AuthProvider>
+    <AccountProvider>
+      <AuthProvider>
+        <Shell />
+      </AuthProvider>
+    </AccountProvider>
   );
 }

--- a/packages/web/src/components/AccountDialog.tsx
+++ b/packages/web/src/components/AccountDialog.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Mail } from "lucide-react";
+import { useAccount } from "../lib/account";
+
+// Sign-in dialog for saving models. Anonymous-first messaging: the canvas is free
+// without an account — you only sign in to keep your work.
+export function AccountDialog({ onClose }: { onClose: () => void }) {
+  const { signInWithGoogle, signInWithGitHub, signInWithEmail } = useAccount();
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [busy, setBusy] = useState<null | "google" | "github" | "email">(null);
+  const [err, setErr] = useState("");
+
+  async function run(which: "google" | "github" | "email", fn: () => Promise<void>) {
+    setBusy(which);
+    setErr("");
+    try {
+      await fn();
+      if (which === "email") setSent(true);
+      // OAuth navigates away; nothing else to do here.
+    } catch (e) {
+      setErr((e as Error).message);
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div
+        className="w-[440px] max-h-[88vh] overflow-y-auto rounded-2xl border border-[#d8dee8] bg-white p-7 shadow-xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <h1 className="text-lg font-semibold">Save your model</h1>
+        <p className="mt-2 text-[13px] leading-relaxed text-slate-500">
+          The canvas is free without an account — sign in only to <span className="font-medium text-slate-700">save and reopen</span> your models. No credit card, no setup.
+        </p>
+
+        {sent ? (
+          <div className="mt-6 rounded-xl border border-[#e6e9f0] bg-[#f7f8fa] p-5 text-center">
+            <Mail className="mx-auto text-[#1e88e5]" size={28} />
+            <p className="mt-3 text-[14px] font-semibold text-slate-800">Check your email</p>
+            <p className="mt-1 text-[13px] text-slate-500">We sent a sign-in link to <span className="font-medium text-slate-700">{email}</span>.</p>
+          </div>
+        ) : (
+          <>
+            <div className="mt-5 flex flex-col gap-2.5">
+              <button
+                onClick={() => run("google", signInWithGoogle)}
+                disabled={!!busy}
+                className="flex items-center justify-center gap-2.5 rounded-lg border border-[#d8dee8] bg-white px-4 py-2.5 text-[14px] font-[550] text-slate-900 hover:bg-[#f1f3f7] disabled:opacity-50 cursor-pointer"
+              >
+                <GoogleMark /> Continue with Google
+              </button>
+              <button
+                onClick={() => run("github", signInWithGitHub)}
+                disabled={!!busy}
+                className="flex items-center justify-center gap-2.5 rounded-lg border border-[#d8dee8] bg-white px-4 py-2.5 text-[14px] font-[550] text-slate-900 hover:bg-[#f1f3f7] disabled:opacity-50 cursor-pointer"
+              >
+                <GitHubMark /> Continue with GitHub
+              </button>
+            </div>
+
+            <div className="my-4 flex items-center gap-3 text-[12px] text-slate-400">
+              <span className="h-px flex-1 bg-[#e6e9f0]" /> or <span className="h-px flex-1 bg-[#e6e9f0]" />
+            </div>
+
+            <div className="flex gap-2">
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter" && email.trim()) void run("email", () => signInWithEmail(email.trim())); }}
+                placeholder="you@company.com"
+                className="flex-1 rounded-lg border border-[#d8dee8] px-3 py-2.5 text-[14px] outline-none focus:border-[#1e88e5]"
+              />
+              <button
+                onClick={() => email.trim() && run("email", () => signInWithEmail(email.trim()))}
+                disabled={!!busy || !email.trim()}
+                className="rounded-lg bg-[#1e88e5] px-4 py-2.5 text-[14px] font-[550] text-white hover:bg-[#1976d2] disabled:opacity-50 cursor-pointer"
+              >
+                {busy === "email" ? "Sending…" : "Email me a link"}
+              </button>
+            </div>
+
+            {err && <p className="mt-3 text-[12.5px] text-red-600">{err}</p>}
+          </>
+        )}
+
+        <button onClick={onClose} className="mt-5 w-full text-[13px] text-slate-500 hover:text-slate-800 cursor-pointer">
+          Maybe later
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function GoogleMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 18 18" aria-hidden>
+      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62Z" />
+      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.02-3.7H.96v2.33A9 9 0 0 0 9 18Z" />
+      <path fill="#FBBC05" d="M3.98 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.02-2.33Z" />
+      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.47.9 11.43 0 9 0A9 9 0 0 0 .96 4.95l3.02 2.33C4.68 5.16 6.66 3.58 9 3.58Z" />
+    </svg>
+  );
+}
+function GitHubMark() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38v-1.34c-2.23.48-2.7-1.07-2.7-1.07-.36-.93-.89-1.18-.89-1.18-.73-.5.05-.49.05-.49.81.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.83-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.52.56.83 1.28.83 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}

--- a/packages/web/src/components/MyModelsDialog.tsx
+++ b/packages/web/src/components/MyModelsDialog.tsx
@@ -3,7 +3,7 @@ import { Trash2, Pencil, FolderOpen } from "lucide-react";
 import type { ModelGraph } from "@mc/okf";
 import { listModels, loadModel, updateModel, deleteModel, type SavedModel } from "../lib/models";
 
-export function MyModelsDialog({ onOpen, onClose }: { onOpen: (graph: ModelGraph, id: string) => void; onClose: () => void }) {
+export function MyModelsDialog({ onOpen, onClose }: { onOpen: (graph: ModelGraph, id: string, name: string) => void; onClose: () => void }) {
   const [models, setModels] = useState<SavedModel[] | null>(null);
   const [err, setErr] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -15,9 +15,9 @@ export function MyModelsDialog({ onOpen, onClose }: { onOpen: (graph: ModelGraph
   }
   useEffect(() => { void refresh(); }, []);
 
-  async function open(id: string) {
+  async function open(id: string, name: string) {
     setBusyId(id); setErr("");
-    try { onOpen(await loadModel(id), id); onClose(); }
+    try { onOpen(await loadModel(id), id, name); onClose(); }
     catch (e) { setErr((e as Error).message); setBusyId(null); }
   }
   async function remove(id: string) {
@@ -59,12 +59,12 @@ export function MyModelsDialog({ onOpen, onClose }: { onOpen: (graph: ModelGraph
                   className="flex-1 rounded-md border border-[#1e88e5] px-2 py-1 text-[14px] outline-none"
                 />
               ) : (
-                <button onClick={() => open(m.id)} disabled={busyId === m.id} className="flex-1 text-left cursor-pointer disabled:opacity-50">
+                <button onClick={() => open(m.id, m.name)} disabled={busyId === m.id} className="flex-1 text-left cursor-pointer disabled:opacity-50">
                   <div className="text-[14px] font-[550] text-slate-900">{m.name}</div>
                   <div className="text-[12px] text-slate-400">Updated {new Date(m.updated_at).toLocaleString()}</div>
                 </button>
               )}
-              <button title="Open" onClick={() => open(m.id)} disabled={busyId === m.id} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-[#e6f1fb] hover:text-[#1e88e5] cursor-pointer"><FolderOpen size={16} /></button>
+              <button title="Open" onClick={() => open(m.id, m.name)} disabled={busyId === m.id} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-[#e6f1fb] hover:text-[#1e88e5] cursor-pointer"><FolderOpen size={16} /></button>
               <button title="Rename" onClick={() => setRenaming({ id: m.id, name: m.name })} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-[#f1f3f7] hover:text-slate-700 cursor-pointer"><Pencil size={15} /></button>
               <button title="Delete" onClick={() => remove(m.id)} disabled={busyId === m.id} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 cursor-pointer"><Trash2 size={15} /></button>
             </div>

--- a/packages/web/src/components/MyModelsDialog.tsx
+++ b/packages/web/src/components/MyModelsDialog.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { Trash2, Pencil, FolderOpen } from "lucide-react";
+import type { ModelGraph } from "@mc/okf";
+import { listModels, loadModel, updateModel, deleteModel, type SavedModel } from "../lib/models";
+
+export function MyModelsDialog({ onOpen, onClose }: { onOpen: (graph: ModelGraph, id: string) => void; onClose: () => void }) {
+  const [models, setModels] = useState<SavedModel[] | null>(null);
+  const [err, setErr] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [renaming, setRenaming] = useState<{ id: string; name: string } | null>(null);
+
+  async function refresh() {
+    try { setModels(await listModels()); }
+    catch (e) { setErr((e as Error).message); }
+  }
+  useEffect(() => { void refresh(); }, []);
+
+  async function open(id: string) {
+    setBusyId(id); setErr("");
+    try { onOpen(await loadModel(id), id); onClose(); }
+    catch (e) { setErr((e as Error).message); setBusyId(null); }
+  }
+  async function remove(id: string) {
+    setBusyId(id); setErr("");
+    try { await deleteModel(id); await refresh(); }
+    catch (e) { setErr((e as Error).message); }
+    finally { setBusyId(null); }
+  }
+  async function commitRename() {
+    if (!renaming) return;
+    const { id, name } = renaming;
+    setRenaming(null);
+    try { await updateModel(id, { name: name.trim() || "Untitled model" }); await refresh(); }
+    catch (e) { setErr((e as Error).message); }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="w-[520px] max-h-[80vh] overflow-y-auto rounded-2xl border border-[#d8dee8] bg-white p-7 shadow-xl" onClick={e => e.stopPropagation()}>
+        <h1 className="text-lg font-semibold">My models</h1>
+        <p className="mt-1 text-[13px] text-slate-500">Open a saved model, or manage your library.</p>
+
+        {err && <p className="mt-3 text-[12.5px] text-red-600">{err}</p>}
+
+        <div className="mt-5 flex flex-col gap-1.5">
+          {models === null && <p className="py-6 text-center text-[13px] text-slate-400">Loading…</p>}
+          {models?.length === 0 && (
+            <p className="py-8 text-center text-[13px] text-slate-400">No saved models yet. Build one and hit <span className="font-medium text-slate-600">Save</span>.</p>
+          )}
+          {models?.map(m => (
+            <div key={m.id} className="group flex items-center gap-2 rounded-lg border border-transparent px-3 py-2.5 hover:border-[#e6e9f0] hover:bg-[#f7f8fa]">
+              {renaming?.id === m.id ? (
+                <input
+                  autoFocus
+                  value={renaming.name}
+                  onChange={e => setRenaming({ id: m.id, name: e.target.value })}
+                  onBlur={commitRename}
+                  onKeyDown={e => { if (e.key === "Enter") void commitRename(); if (e.key === "Escape") setRenaming(null); }}
+                  className="flex-1 rounded-md border border-[#1e88e5] px-2 py-1 text-[14px] outline-none"
+                />
+              ) : (
+                <button onClick={() => open(m.id)} disabled={busyId === m.id} className="flex-1 text-left cursor-pointer disabled:opacity-50">
+                  <div className="text-[14px] font-[550] text-slate-900">{m.name}</div>
+                  <div className="text-[12px] text-slate-400">Updated {new Date(m.updated_at).toLocaleString()}</div>
+                </button>
+              )}
+              <button title="Open" onClick={() => open(m.id)} disabled={busyId === m.id} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-[#e6f1fb] hover:text-[#1e88e5] cursor-pointer"><FolderOpen size={16} /></button>
+              <button title="Rename" onClick={() => setRenaming({ id: m.id, name: m.name })} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-[#f1f3f7] hover:text-slate-700 cursor-pointer"><Pencil size={15} /></button>
+              <button title="Delete" onClick={() => remove(m.id)} disabled={busyId === m.id} className="rounded-md p-1.5 text-slate-400 opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 cursor-pointer"><Trash2 size={15} /></button>
+            </div>
+          ))}
+        </div>
+
+        <button onClick={onClose} className="mt-5 w-full text-[13px] text-slate-500 hover:text-slate-800 cursor-pointer">Close</button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/TopBar.tsx
+++ b/packages/web/src/components/TopBar.tsx
@@ -29,6 +29,9 @@ export interface TopBarProps {
   onOpenGoal?: () => void;
   goalSet?: boolean;
   questionsEnabled?: boolean;
+  // Editable model name, shown next to the brand and used as the Save default.
+  modelName?: string;
+  onRenameModel?: (name: string) => void;
   // Supabase account ("Save"). Independent of the OWOX connect/sign-in above.
   supabaseEnabled?: boolean;
   accountEmail?: string | null;
@@ -67,12 +70,23 @@ export function TopBar({
   onShare, shareDisabled = false, onPush, onLibrary,
   signedIn, projectTitle, onSignIn, onSignOut,
   onOpenGoal, goalSet = false, questionsEnabled = false,
+  modelName, onRenameModel,
   supabaseEnabled = false, accountEmail, onSave, saving = false, onMyModels, onAccountSignOut,
 }: TopBarProps) {
   // Push split-button menu (holds the signed-in "Import from OWOX project" action).
   const [menuOpen, setMenuOpen] = useState(false);
   // Supabase account dropdown.
   const [acctOpen, setAcctOpen] = useState(false);
+  // Inline model-name editing.
+  const [editingName, setEditingName] = useState(false);
+  const [draftName, setDraftName] = useState(modelName ?? "");
+  useEffect(() => { setDraftName(modelName ?? ""); }, [modelName]);
+  const commitName = () => {
+    setEditingName(false);
+    const n = draftName.trim();
+    if (n && n !== modelName) onRenameModel?.(n);
+    else setDraftName(modelName ?? "");
+  };
   // Export dropdown (OKF markdown / PNG / SVG).
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   // Show the Library hint on first ever visit; stays lit until hovered.
@@ -101,6 +115,34 @@ export function TopBar({
         </a>
         <span>Model Canvas</span>
       </div>
+
+      {/* Editable model name — click to rename. Used as the Save default. */}
+      {modelName != null && (
+        <>
+          <span className="select-none text-slate-300">/</span>
+          {editingName ? (
+            <input
+              autoFocus
+              value={draftName}
+              onChange={e => setDraftName(e.target.value)}
+              onBlur={commitName}
+              onKeyDown={e => {
+                if (e.key === "Enter") commitName();
+                if (e.key === "Escape") { setDraftName(modelName); setEditingName(false); }
+              }}
+              className="w-[260px] rounded-md border border-[#1e88e5] px-2 py-[3px] text-[13px] font-[550] text-slate-900 outline-none"
+            />
+          ) : (
+            <button
+              onClick={() => setEditingName(true)}
+              title="Rename model"
+              className="max-w-[280px] cursor-text truncate rounded-md px-2 py-[3px] text-[13px] font-[550] text-slate-700 hover:bg-[#f1f3f7]"
+            >
+              {modelName}
+            </button>
+          )}
+        </>
+      )}
 
       {/* Business Goal — entry point for Insight Questions. Hidden unless the
           server reports GEMINI_API_KEY is set (questionsEnabled), so it's a pure

--- a/packages/web/src/components/TopBar.tsx
+++ b/packages/web/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Download, Upload, ChevronDown, Target, Share2, FileText, Image as ImageIcon } from "lucide-react";
+import { Download, Upload, ChevronDown, Target, Share2, FileText, Image as ImageIcon, Save, FolderOpen, LogOut } from "lucide-react";
 import { ProjectIcon, StorageIcon, LibraryIcon } from "../lib/icons";
 
 // First-visit onboarding hint pointing at the Library. Persisted so it only
@@ -29,6 +29,13 @@ export interface TopBarProps {
   onOpenGoal?: () => void;
   goalSet?: boolean;
   questionsEnabled?: boolean;
+  // Supabase account ("Save"). Independent of the OWOX connect/sign-in above.
+  supabaseEnabled?: boolean;
+  accountEmail?: string | null;
+  onSave?: () => void;
+  saving?: boolean;
+  onMyModels?: () => void;
+  onAccountSignOut?: () => void;
 }
 
 const LOGO = (
@@ -60,9 +67,12 @@ export function TopBar({
   onShare, shareDisabled = false, onPush, onLibrary,
   signedIn, projectTitle, onSignIn, onSignOut,
   onOpenGoal, goalSet = false, questionsEnabled = false,
+  supabaseEnabled = false, accountEmail, onSave, saving = false, onMyModels, onAccountSignOut,
 }: TopBarProps) {
   // Push split-button menu (holds the signed-in "Import from OWOX project" action).
   const [menuOpen, setMenuOpen] = useState(false);
+  // Supabase account dropdown.
+  const [acctOpen, setAcctOpen] = useState(false);
   // Export dropdown (OKF markdown / PNG / SVG).
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   // Show the Library hint on first ever visit; stays lit until hovered.
@@ -200,6 +210,52 @@ export function TopBar({
       >
         <Share2 size={15} /> Share
       </button>
+
+      {/* Save to your account (Supabase). Anonymous-first: clicking while signed
+          out opens the sign-in dialog; create/edit/export never need an account.
+          Hidden entirely when Supabase isn't configured (env kill-switch). */}
+      {supabaseEnabled && (
+        <>
+          <button
+            onClick={onSave}
+            disabled={saving}
+            title={accountEmail ? "Save this model to your account" : "Sign in to save this model"}
+            className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-3 py-[7px] cursor-pointer flex items-center gap-[6px] hover:bg-[#f1f3f7] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Save size={15} /> {saving ? "Saving…" : "Save"}
+          </button>
+          {accountEmail && (
+            <div className="relative">
+              <button
+                onClick={() => setAcctOpen(o => !o)}
+                aria-haspopup="menu"
+                aria-expanded={acctOpen}
+                title={accountEmail}
+                className="flex items-center gap-[6px] rounded-lg border border-[#d8dee8] bg-white px-[8px] py-[5px] cursor-pointer hover:bg-[#f1f3f7]"
+              >
+                <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[#1e88e5] text-[12px] font-semibold text-white">
+                  {accountEmail.trim().charAt(0).toUpperCase()}
+                </span>
+                <ChevronDown size={14} className="text-slate-400" />
+              </button>
+              {acctOpen && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setAcctOpen(false)} />
+                  <div role="menu" className="absolute top-[calc(100%+6px)] right-0 z-50 w-[232px] rounded-lg border border-[#d8dee8] bg-white shadow-[0_8px_24px_rgba(15,23,42,0.18)] py-1">
+                    <div className="truncate px-3 py-2 text-[12px] text-slate-400 border-b border-[#eef1f5]">{accountEmail}</div>
+                    <button role="menuitem" onClick={() => { setAcctOpen(false); onMyModels?.(); }} className="w-full text-left text-[13px] text-slate-900 px-3 py-2 cursor-pointer flex items-center gap-[8px] hover:bg-[#f1f3f7]">
+                      <FolderOpen size={15} className="text-slate-500" /> My models
+                    </button>
+                    <button role="menuitem" onClick={() => { setAcctOpen(false); onAccountSignOut?.(); }} className="w-full text-left text-[13px] text-slate-900 px-3 py-2 cursor-pointer flex items-center gap-[8px] hover:bg-[#f1f3f7]">
+                      <LogOut size={15} className="text-slate-500" /> Sign out
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </>
+      )}
 
       {/* Push to OWOX — split button: primary push + caret menu (signed-in only)
           holding the less-common "Import from OWOX project" action. */}

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -25,6 +25,7 @@ import { X, Sparkles, MessageSquare } from "lucide-react";
 import { createModelStore } from "../../state/model";
 import { loadPersistedGraph, persistGraph } from "../../state/persist";
 import { loadViewMode, persistViewMode, type ViewMode } from "../../state/viewMode";
+import { loadModelName, persistModelName, DEFAULT_MODEL_NAME, templateModelName } from "../../state/modelName";
 import type { ModelNode, ModelEdge, ModelGraph } from "@mc/okf";
 
 import { graphToBundleFiles, downloadBundle } from "../../okf/io";
@@ -200,6 +201,9 @@ function CanvasInner() {
   // The id of the saved model currently open (so Save updates it instead of
   // creating a duplicate). Reset on Clear / opening a different model.
   const [savedModelId, setSavedModelId] = useState<string | null>(null);
+  // Editable model name (shown in the top bar, used as the Save default).
+  const [modelName, setModelName] = useState(loadModelName());
+  useEffect(() => { persistModelName(modelName); }, [modelName]);
 
   // Load the project's storages once signed in; retry through OWOX's transient
   // 500s. Anonymous users have no session, so we skip the call entirely and
@@ -395,6 +399,7 @@ function CanvasInner() {
     setSelection(null);
     setShowClear(false);
     setSavedModelId(null); // a cleared canvas is a fresh model — next Save creates a new row
+    setModelName(DEFAULT_MODEL_NAME);
   }, []);
 
   const handleExportAndClear = useCallback(() => {
@@ -476,12 +481,11 @@ function CanvasInner() {
     setSaving(true);
     try {
       const graph = store.get();
+      const name = modelName.trim() || DEFAULT_MODEL_NAME;
       if (savedModelId) {
-        await updateModel(savedModelId, { graph });
+        await updateModel(savedModelId, { name, graph });
       } else {
-        const name = window.prompt("Name this model:", "Untitled model");
-        if (name === null) return; // cancelled
-        const id = await createModel(name.trim() || "Untitled model", graph);
+        const id = await createModel(name, graph);
         setSavedModelId(id);
       }
       setShareToast("Model saved");
@@ -490,13 +494,14 @@ function CanvasInner() {
     } finally {
       setSaving(false);
     }
-  }, [account, savedModelId]);
+  }, [account, savedModelId, modelName]);
 
   // Open a saved model. It already carries layout positions, so load it straight
   // in (no re-layout) and remember its id so the next Save updates it.
-  const handleOpenSaved = useCallback((g: ModelGraph, id: string) => {
+  const handleOpenSaved = useCallback((g: ModelGraph, id: string, name: string) => {
     store.set({ ...g });
     setSavedModelId(id);
+    setModelName(name);
   }, []);
 
   const handleUseTemplate = useCallback((g: ModelGraph, name: string) => {
@@ -506,6 +511,8 @@ function CanvasInner() {
     // Merge first (mirrors the OKF/OWOX import dialogs) so existing work isn't
     // silently wiped.
     if (store.get().nodes.length === 0) {
+      setModelName(templateModelName(name)); // "My {template} OKF with OWOX"
+      setSavedModelId(null); // a fresh model from a template, not the open saved one
       applyTemplate(g, "replace");
       setShowLibrary(false);
     } else {
@@ -514,7 +521,12 @@ function CanvasInner() {
   }, [applyTemplate]);
 
   const handleTemplateApplyConfirm = useCallback((mode: "replace" | "merge") => {
-    if (pendingTemplate) applyTemplate(pendingTemplate.graph, mode);
+    if (pendingTemplate) {
+      // Replacing = a fresh model from this template, so re-seed the name; merging
+      // keeps the current model (and its name) and just folds the template in.
+      if (mode === "replace") { setModelName(templateModelName(pendingTemplate.name)); setSavedModelId(null); }
+      applyTemplate(pendingTemplate.graph, mode);
+    }
     setPendingTemplate(null);
     setShowLibrary(false);
   }, [pendingTemplate, applyTemplate]);
@@ -593,6 +605,8 @@ function CanvasInner() {
         projectTitle={me?.projectTitle}
         onSignIn={() => setSignIn({ mode: "connect" })}
         onSignOut={handleSignOut}
+        modelName={modelName}
+        onRenameModel={setModelName}
         supabaseEnabled={supabaseEnabled}
         accountEmail={account?.email ?? null}
         onSave={handleSave}

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -37,6 +37,7 @@ import { api } from "../../lib/api";
 import { useAuth } from "../../lib/auth";
 import { useAccount } from "../../lib/account";
 import { supabaseEnabled } from "../../lib/supabase";
+import { isAuthRedirecting } from "../../lib/authRedirect";
 import { createModel, updateModel } from "../../lib/models";
 import { AccountDialog } from "../AccountDialog";
 import { MyModelsDialog } from "../MyModelsDialog";
@@ -264,6 +265,7 @@ function CanvasInner() {
   // session and may not all be in OWOX yet.
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
+      if (isAuthRedirecting()) return; // intentional OAuth redirect, not a real exit
       if (!store.get().nodes.some(n => n.status !== "created")) return;
       e.preventDefault();
       e.returnValue = ""; // required for Chrome to show the native prompt

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -35,6 +35,11 @@ import { detachFromOwox } from "../../sync/detach";
 
 import { api } from "../../lib/api";
 import { useAuth } from "../../lib/auth";
+import { useAccount } from "../../lib/account";
+import { supabaseEnabled } from "../../lib/supabase";
+import { createModel, updateModel } from "../../lib/models";
+import { AccountDialog } from "../AccountDialog";
+import { MyModelsDialog } from "../MyModelsDialog";
 import { TopBar, type StorageOption } from "../TopBar";
 import { ImportDialog } from "../ImportDialog";
 import { OwoxImportDialog } from "../OwoxImportDialog";
@@ -186,6 +191,14 @@ function CanvasInner() {
   const [showPushConfirm, setShowPushConfirm] = useState(false);
   const [showClear, setShowClear] = useState(false);
   const { me, connect, signOut } = useAuth();
+  // Supabase account ("Save your model") — independent of the OWOX connect above.
+  const { user: account, signOut: accountSignOut } = useAccount();
+  const [showAccount, setShowAccount] = useState(false);
+  const [showMyModels, setShowMyModels] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // The id of the saved model currently open (so Save updates it instead of
+  // creating a duplicate). Reset on Clear / opening a different model.
+  const [savedModelId, setSavedModelId] = useState<string | null>(null);
 
   // Load the project's storages once signed in; retry through OWOX's transient
   // 500s. Anonymous users have no session, so we skip the call entirely and
@@ -379,6 +392,7 @@ function CanvasInner() {
     store.set({ storageId: store.get().storageId, nodes: [], edges: [] });
     setSelection(null);
     setShowClear(false);
+    setSavedModelId(null); // a cleared canvas is a fresh model — next Save creates a new row
   }, []);
 
   const handleExportAndClear = useCallback(() => {
@@ -451,6 +465,37 @@ function CanvasInner() {
     if (mode === "merge") applyMergeWithLayout(g);
     else store.set({ ...withLayout(g), storageId: store.get().storageId });
   }, [withLayout, applyMergeWithLayout]);
+
+  // Save to the Supabase account. Anonymous-first: if not signed in, open the
+  // sign-in dialog instead (the user clicks Save again after returning). On an
+  // already-saved model, update it in place; otherwise create a new row.
+  const handleSave = useCallback(async () => {
+    if (!account) { setShowAccount(true); return; }
+    setSaving(true);
+    try {
+      const graph = store.get();
+      if (savedModelId) {
+        await updateModel(savedModelId, { graph });
+      } else {
+        const name = window.prompt("Name this model:", "Untitled model");
+        if (name === null) return; // cancelled
+        const id = await createModel(name.trim() || "Untitled model", graph);
+        setSavedModelId(id);
+      }
+      setShareToast("Model saved");
+    } catch (e) {
+      setShareToast(`Save failed: ${(e as Error).message}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [account, savedModelId]);
+
+  // Open a saved model. It already carries layout positions, so load it straight
+  // in (no re-layout) and remember its id so the next Save updates it.
+  const handleOpenSaved = useCallback((g: ModelGraph, id: string) => {
+    store.set({ ...g });
+    setSavedModelId(id);
+  }, []);
 
   const handleUseTemplate = useCallback((g: ModelGraph, name: string) => {
     // Remember the matching niche so the Business Goal dialog can pre-pick it.
@@ -546,7 +591,15 @@ function CanvasInner() {
         projectTitle={me?.projectTitle}
         onSignIn={() => setSignIn({ mode: "connect" })}
         onSignOut={handleSignOut}
+        supabaseEnabled={supabaseEnabled}
+        accountEmail={account?.email ?? null}
+        onSave={handleSave}
+        saving={saving}
+        onMyModels={() => setShowMyModels(true)}
+        onAccountSignOut={() => { void accountSignOut(); setSavedModelId(null); }}
       />
+      {showAccount && <AccountDialog onClose={() => setShowAccount(false)} />}
+      {showMyModels && <MyModelsDialog onOpen={handleOpenSaved} onClose={() => setShowMyModels(false)} />}
       {shareToast && <ShareToast message={shareToast} onClose={() => setShareToast(null)} />}
       {pushing && (
         <div className="fixed bottom-4 right-4 z-50 bg-slate-900 text-white text-[13px] px-4 py-2 rounded-lg shadow-lg">

--- a/packages/web/src/lib/account.tsx
+++ b/packages/web/src/lib/account.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase, supabaseEnabled } from "./supabase";
+import { setAuthRedirecting } from "./authRedirect";
 
 // The Supabase account = the user's identity, used to SAVE models. This is a
 // separate concern from `lib/auth.tsx` (the OWOX API-key "connect" flow used for
@@ -42,11 +43,14 @@ export function AccountProvider({ children }: { children: ReactNode }) {
   // then picks the session out of the URL (detectSessionInUrl) on return.
   const oauth = (provider: "google" | "github") => async () => {
     if (!supabase) return;
+    // We're about to leave the page for the provider — suppress the unsaved-work
+    // "Leave site?" prompt for this intentional navigation.
+    setAuthRedirecting(true);
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: { redirectTo: window.location.origin },
     });
-    if (error) throw error;
+    if (error) { setAuthRedirecting(false); throw error; }
   };
 
   const signInWithEmail = async (email: string) => {

--- a/packages/web/src/lib/account.tsx
+++ b/packages/web/src/lib/account.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase, supabaseEnabled } from "./supabase";
+
+// The Supabase account = the user's identity, used to SAVE models. This is a
+// separate concern from `lib/auth.tsx` (the OWOX API-key "connect" flow used for
+// Push) — a user can be signed into their account without connecting OWOX, and
+// vice-versa. Anonymous-first: nothing here gates create/edit/export/share.
+
+interface AccountCtx {
+  enabled: boolean;
+  ready: boolean;
+  user: User | null;
+  signInWithGoogle: () => Promise<void>;
+  signInWithGitHub: () => Promise<void>;
+  signInWithEmail: (email: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const Ctx = createContext<AccountCtx>(null!);
+export const useAccount = () => useContext(Ctx);
+
+export function AccountProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  // When Supabase isn't configured the feature is simply off — treat as "ready"
+  // immediately so nothing waits on it.
+  const [ready, setReady] = useState(!supabaseEnabled);
+
+  useEffect(() => {
+    if (!supabase) return;
+    void supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null);
+      setReady(true);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  // OAuth redirects the page to the provider and back to `redirectTo`; supabase-js
+  // then picks the session out of the URL (detectSessionInUrl) on return.
+  const oauth = (provider: "google" | "github") => async () => {
+    if (!supabase) return;
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: window.location.origin },
+    });
+    if (error) throw error;
+  };
+
+  const signInWithEmail = async (email: string) => {
+    if (!supabase) return;
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin },
+    });
+    if (error) throw error;
+  };
+
+  const signOut = async () => {
+    await supabase?.auth.signOut();
+    setUser(null);
+  };
+
+  return (
+    <Ctx.Provider
+      value={{
+        enabled: supabaseEnabled,
+        ready,
+        user,
+        signInWithGoogle: oauth("google"),
+        signInWithGitHub: oauth("github"),
+        signInWithEmail,
+        signOut,
+      }}
+    >
+      {children}
+    </Ctx.Provider>
+  );
+}

--- a/packages/web/src/lib/authRedirect.ts
+++ b/packages/web/src/lib/authRedirect.ts
@@ -1,0 +1,6 @@
+// Set true right before an intentional OAuth redirect (Google/GitHub) so the
+// canvas's "unsaved work" beforeunload guard doesn't prompt the user with
+// "Leave site?" as they're deliberately leaving for the provider and back.
+let redirecting = false;
+export const setAuthRedirecting = (v: boolean) => { redirecting = v; };
+export const isAuthRedirecting = () => redirecting;

--- a/packages/web/src/lib/models.ts
+++ b/packages/web/src/lib/models.ts
@@ -1,0 +1,56 @@
+import type { ModelGraph } from "@mc/okf";
+import { supabase } from "./supabase";
+
+// CRUD for saved models. The browser talks to Supabase directly; RLS scopes every
+// query to the signed-in user, so we never pass a user id on reads.
+
+export interface SavedModel {
+  id: string;
+  name: string;
+  updated_at: string;
+}
+
+function client() {
+  if (!supabase) throw new Error("Saving is not configured.");
+  return supabase;
+}
+
+export async function listModels(): Promise<SavedModel[]> {
+  const { data, error } = await client()
+    .from("models")
+    .select("id,name,updated_at")
+    .order("updated_at", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as SavedModel[];
+}
+
+export async function loadModel(id: string): Promise<ModelGraph> {
+  const { data, error } = await client().from("models").select("graph").eq("id", id).single();
+  if (error) throw error;
+  return (data as { graph: ModelGraph }).graph;
+}
+
+/** Insert a new saved model. Returns its id. */
+export async function createModel(name: string, graph: ModelGraph): Promise<string> {
+  const sb = client();
+  const { data: u } = await sb.auth.getUser();
+  const userId = u.user?.id;
+  if (!userId) throw new Error("Sign in to save.");
+  const { data, error } = await sb
+    .from("models")
+    .insert({ user_id: userId, name, graph })
+    .select("id")
+    .single();
+  if (error) throw error;
+  return (data as { id: string }).id;
+}
+
+export async function updateModel(id: string, patch: { name?: string; graph?: ModelGraph }): Promise<void> {
+  const { error } = await client().from("models").update(patch).eq("id", id);
+  if (error) throw error;
+}
+
+export async function deleteModel(id: string): Promise<void> {
+  const { error } = await client().from("models").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/packages/web/src/lib/supabase.ts
+++ b/packages/web/src/lib/supabase.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// "Sign up to save" connects the browser straight to Supabase (Auth + DB), with
+// Row-Level Security as the boundary — so there's no server secret and almost no
+// server change. Both values are PUBLIC by design (the anon/publishable key is
+// meant to ship in the client).
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const key = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+// Feature flag: the whole account/save UI turns on only when the project is
+// configured. Unset → the anonymous canvas is unchanged. Mirrors the GEMINI /
+// PostHog env kill-switches already used here.
+export const supabaseEnabled: boolean = !!url && !!key;
+
+export const supabase: SupabaseClient | null = supabaseEnabled
+  ? createClient(url!, key!, {
+      auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true },
+    })
+  : null;

--- a/packages/web/src/state/modelName.ts
+++ b/packages/web/src/state/modelName.ts
@@ -1,0 +1,27 @@
+// The model's display name — shown (and edited) in the top bar, used as the
+// default when saving to an account. Persisted so a refresh keeps it, mirroring
+// how the model itself and the business goal are persisted.
+const KEY = "mc.modelName.v1";
+
+export const DEFAULT_MODEL_NAME = "My first OKF with OWOX";
+
+/** Default name for a model started from a template, e.g. "My SaaS / Subscription OKF with OWOX". */
+export function templateModelName(templateName: string): string {
+  return `My ${templateName} OKF with OWOX`;
+}
+
+export function loadModelName(): string {
+  try {
+    return localStorage.getItem(KEY) || DEFAULT_MODEL_NAME;
+  } catch {
+    return DEFAULT_MODEL_NAME;
+  }
+}
+
+export function persistModelName(name: string): void {
+  try {
+    localStorage.setItem(KEY, name);
+  } catch {
+    // Ignore quota / private-mode failures — persistence is best-effort.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@mc/okf':
         specifier: workspace:*
         version: link:../okf
+      '@supabase/supabase-js':
+        specifier: ^2.108.2
+        version: 2.108.2
       '@xyflow/react':
         specifier: ^12.3.0
         version: 12.11.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -756,6 +759,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
+    engines: {node: '>=20.0.0'}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1304,6 +1334,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1830,6 +1864,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
@@ -2467,6 +2504,38 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
 
+  '@supabase/auth-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.108.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.108.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.108.2':
+    dependencies:
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3094,6 +3163,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iceberg-js@0.8.1: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -3589,6 +3660,8 @@ snapshots:
       punycode: 2.3.1
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.22.4:
     dependencies:

--- a/render.yaml
+++ b/render.yaml
@@ -22,3 +22,11 @@ services:
       # preview deploys → analytics stays off there.
       - key: VITE_POSTHOG_KEY
         sync: false
+      # Supabase "sign up to save". Public client-side values (RLS is the security
+      # boundary), inlined into the web build by Vite — so they must be present at
+      # build time. Unset → the account/save feature self-disables. Set both in the
+      # dashboard.
+      - key: VITE_SUPABASE_URL
+        sync: false
+      - key: VITE_SUPABASE_ANON_KEY
+        sync: false

--- a/supabase/migrations/0001_models.sql
+++ b/supabase/migrations/0001_models.sql
@@ -1,0 +1,40 @@
+-- "Sign up to save" — per-user saved models.
+--
+-- The model is stored as the full ModelGraph (jsonb) so a save round-trips
+-- losslessly (positions, OWOX status, everything) — unlike OKF export, which
+-- re-lays-out on load. Export OKF stays the portable format; this is the editor's
+-- own save. (#4953 version control will snapshot this jsonb per save → text diff.)
+
+create table if not exists public.models (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid not null references auth.users (id) on delete cascade,
+  name       text not null default 'Untitled model',
+  graph      jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists models_user_updated_idx on public.models (user_id, updated_at desc);
+
+-- Row-Level Security: a row is visible/mutable only by its owner. This is why the
+-- anon/publishable key is safe to ship in the browser — these policies, not the
+-- key, are the boundary.
+alter table public.models enable row level security;
+
+create policy "owner can read"   on public.models for select using (auth.uid() = user_id);
+create policy "owner can insert" on public.models for insert with check (auth.uid() = user_id);
+create policy "owner can update" on public.models for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "owner can delete" on public.models for delete using (auth.uid() = user_id);
+
+-- keep updated_at fresh on every save
+create or replace function public.touch_updated_at()
+  returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+drop trigger if exists models_touch_updated_at on public.models;
+create trigger models_touch_updated_at
+  before update on public.models
+  for each row execute function public.touch_updated_at();


### PR DESCRIPTION
## What
Optional accounts so users can **save and reopen** their models — converts launch traffic into accounts. **Anonymous-first:** create / edit / export / share never require an account; only **Save** prompts sign-in. Behind an env flag that **self-disables when Supabase isn't configured**, so it's safe to merge before prod is wired.

## What's included
- **Save / My models** with sign-in via **Google + GitHub + email magic-link** (all three verified working).
- **Editable model name** in the top bar (replaces the old `window.prompt`); seeds to `My first OKF with OWOX`, or `My {template} OKF with OWOX` from a template; restored when reopening a saved model.
- **Client-direct Supabase** (Auth + DB + Row-Level Security) → no `service_role`, no server secret.
- `supabase/migrations/0001_models.sql`: `models` table (full ModelGraph as `jsonb`, lossless) + **owner-only RLS**.
- **CSP fix** (server): `connect-src` now allows `https://*.supabase.co` — without it every Supabase call is blocked (`Failed to fetch`), which would break prod too.
- **OAuth UX:** the "unsaved work" `beforeunload` prompt is bypassed during the intentional sign-in redirect.

## Config — no secrets in the repo
Two **public** env vars (RLS is the boundary), declared in `render.yaml` (`sync: false`) and documented in `packages/web/.env.example`: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.

## To turn it on in prod (owner)
1. Apply `supabase/migrations/0001_models.sql` to the Supabase project.
2. Set the two `VITE_SUPABASE_*` vars in Render. (Providers + redirect URLs are already configured on the project.)

## Testing
`tsc --noEmit` clean; **web 173/173 + server 36/36** green; browser-verified — sign-in dialog + name editor render, live Supabase fetch returns 200, and the round-trip works via email + Google + GitHub.

## Follow-ups (separate stacked PR)
Version control / OKF-diff (#4953), a left models-nav rail + account/OWOX coexistence (#4956), and sharing the *named* model. Usage metering (feeds the pricing decision) after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)