### PR TITLE
fix: make sign-in trust note accurate about token scope

### DIFF
--- a/packages/web/src/components/SignInModal.tsx
+++ b/packages/web/src/components/SignInModal.tsx
@@ -106,9 +106,9 @@ export function SignInModal({ mode, connect, onConnected, onClose }: SignInModal
         <div className="mt-3 flex items-start gap-2 rounded-lg border border-[#e6e9f0] bg-[#f7f8fa] px-3 py-2.5 text-[12px] leading-relaxed text-slate-600">
           <ShieldCheck size={15} className="mt-[1px] flex-shrink-0 text-[#1e88e5]" />
           <span>
-            We exchange your key for a short-lived access token held <b>only in memory</b> on the server —
-            never stored at rest, and used solely to push your model. The key stays in your browser and is
-            cleared when you sign out. It's{" "}
+            We exchange your key for an access token held <b>only in memory</b> on the server —
+            never stored at rest, and used only for this session to read and update Data Marts in your
+            project. The key stays in your browser and is cleared when you sign out. It's{" "}
             <a
               href="https://github.com/OWOX/owox-model-canvas/blob/main/packages/server/src/auth/session.ts"
               target="_blank"


### PR DESCRIPTION
## What

Reword the trust note in the **Sign in to push** modal so it matches what the code actually does.

### Before
> We exchange your key for a **short-lived** access token held only in memory on the server — never stored at rest, and **used solely to push your model**. The key stays in your browser and is cleared when you sign out.

### After
> We exchange your key for an access token held only in memory on the server — never stored at rest, and **used only for this session to read and update Data Marts in your project**. The key stays in your browser and is cleared when you sign out.

## Why

Two claims overstated the guarantees:

- **"used solely to push your model"** — inaccurate. The session token grants full read+write to the OWOX project. Routes use it for reads (`listStorages`, `listDataMarts`, `getDataMart`, `/api/owox-import`) and writes including **delete** (`createDataMart`, `updateTitle/description/schema/definition`, `createRelationship`, `deleteDataMart`).
- **"short-lived"** — the only lifetime bound is our 12h in-memory session TTL (`session.ts`), not a property of the token we control or verify. Dropped the word.

The accurate claims are kept unchanged: token held **only in memory**, **never stored at rest**, key **stays in the browser** and is **cleared on sign out** — all verified against `packages/server/src/auth/session.ts` and `auth.tsx`.

## Scope

Copy-only change in `packages/web/src/components/SignInModal.tsx`. No behavior change; no tests reference this string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)