### PR TITLE
Import OKF bundle from a public GitHub URL + marketing deeplink

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -48,7 +48,17 @@ export function buildApp() {
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", "data:", "blob:"],
         fontSrc: ["'self'", "data:"],
-        connectSrc: ["'self'", POSTHOG_PROXY, ...supabaseConnect],
+        // raw.githubusercontent.com: client-side OKF-bundle import fetches the
+        // markdown files directly; api.github.com: fallback folder listing when a
+        // bundle has no index.md. Both are static/public read endpoints — no SSRF
+        // surface (the fetch is client-side to fixed hosts).
+        connectSrc: [
+          "'self'",
+          POSTHOG_PROXY,
+          ...supabaseConnect,
+          "https://raw.githubusercontent.com",
+          "https://api.github.com",
+        ],
         workerSrc: ["'self'", "blob:"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -143,6 +143,23 @@ describe("ImportDialog GitHub URL import", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
+  it("rejects a URL with no OKF marts: shows an error, no count, Import disabled", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/";
+    vi.stubGlobal("fetch", vi.fn(async (u: string) => {
+      // index.md exists but only links to sub-folders (no .md marts).
+      const bodies: Record<string, string> = {
+        [base + "index.md"]: "# Bundles\n\n- [demo-project](./demo-project)\n",
+      };
+      const body = bodies[u];
+      return { ok: body != null, status: body != null ? 200 : 404, text: async () => body ?? "" } as Response;
+    }));
+
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} initialUrl="https://github.com/OWOX/models/tree/main/bundles" />);
+    await waitFor(() => expect(screen.getByText(/no okf marts found/i)).toBeTruthy());
+    expect(screen.queryByText(/Will import/i)).toBeNull();
+    expect((screen.getByRole("button", { name: /^import$/i }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("keeps each tab autonomous: the GitHub preview does not show on other tabs", async () => {
     const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
     vi.stubGlobal("fetch", vi.fn(async (url: string) => {

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -39,7 +39,8 @@ describe("import zipped bundle", () => {
 describe("ImportDialog UI", () => {
   it("previews counts after paste (on the Paste tab) and confirms with the chosen mode", async () => {
     const onConfirm = vi.fn();
-    render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} />);
+    // hasExistingModel: the canvas already has a model, so Replace/Merge shows.
+    render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} hasExistingModel />);
     // No preview/counts before any input.
     expect(screen.queryByText(/Will import/i)).toBeNull();
     // The paste textarea lives on the "Paste markdown" tab.
@@ -53,6 +54,21 @@ describe("ImportDialog UI", () => {
     expect(graph.nodes.map((n: { title: string }) => n.title)).toContain("Customers");
     expect(graph.nodes[0].status).toBe("pending");
     expect(mode).toBe("merge");
+  });
+
+  it("hides Replace/Merge on an empty canvas and imports as replace", async () => {
+    const onConfirm = vi.fn();
+    // Default hasExistingModel=false → empty canvas, no apply-mode question.
+    render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /paste markdown/i }));
+    fireEvent.change(screen.getByPlaceholderText(/path\/to\/file\.md/i), { target: { value: PASTE } });
+    await waitFor(() => expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy());
+    // The apply-mode block is absent.
+    expect(screen.queryByText(/When applying to the canvas/i)).toBeNull();
+    expect(screen.queryByText(/Replace the canvas/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][1]).toBe("replace");
   });
 
   it("switches tabs via the segmented control", () => {

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -37,11 +37,13 @@ describe("import zipped bundle", () => {
 });
 
 describe("ImportDialog UI", () => {
-  it("previews counts after paste and confirms with the chosen mode", async () => {
+  it("previews counts after paste (on the Paste tab) and confirms with the chosen mode", async () => {
     const onConfirm = vi.fn();
     render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} />);
     // No preview/counts before any input.
     expect(screen.queryByText(/Will import/i)).toBeNull();
+    // The paste textarea lives on the "Paste markdown" tab.
+    fireEvent.click(screen.getByRole("button", { name: /paste markdown/i }));
     fireEvent.change(screen.getByPlaceholderText(/path\/to\/file\.md/i), { target: { value: PASTE } });
     await waitFor(() => expect(screen.getByText(/Will import 1 marts, 0 relationships/i)).toBeTruthy());
     fireEvent.click(screen.getByText(/Merge into the canvas/i));
@@ -52,22 +54,34 @@ describe("ImportDialog UI", () => {
     expect(graph.nodes[0].status).toBe("pending");
     expect(mode).toBe("merge");
   });
+
+  it("switches tabs via the segmented control", () => {
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} />);
+    // Upload tab is the default: the file input is present, URL input is not.
+    expect(screen.getByText(/Upload \.md/i)).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/github\.com/i)).toBeNull();
+    // Switch to the GitHub tab.
+    fireEvent.click(screen.getByRole("button", { name: /from github/i }));
+    expect(screen.getByPlaceholderText(/github\.com/i)).toBeTruthy();
+    expect(screen.queryByText(/Upload \.md/i)).toBeNull();
+  });
 });
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("ImportDialog GitHub URL import", () => {
-  it("renders the GitHub URL input", () => {
+  it("renders the GitHub URL input on the GitHub tab", () => {
     render(<ImportDialog onConfirm={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /from github/i }));
     expect(screen.getByPlaceholderText(/github\.com/i)).toBeTruthy();
-    expect(screen.getByRole("button", { name: /fetch/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^fetch$/i })).toBeTruthy();
   });
 
-  it("prefills and auto-fetches when initialUrl is given, then previews the bundle", async () => {
+  it("opens the GitHub tab, prefills, auto-fetches, and previews the model (name + objects) when initialUrl is given", async () => {
     const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
     vi.stubGlobal("fetch", vi.fn(async (url: string) => {
       const bodies: Record<string, string> = {
-        [base + "index.md"]: "[Orders](./orders.md)",
+        [base + "index.md"]: "---\ntitle: Demo Project\n---\n[Orders](./orders.md)",
         [base + "orders.md"]: "---\ntitle: Orders\ntype: OWOX Data Mart\n---\n\n## Schema\n\n- id INTEGER\n",
       };
       const body = bodies[url];
@@ -78,10 +92,14 @@ describe("ImportDialog GitHub URL import", () => {
     const onConfirm = vi.fn();
     render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} initialUrl={url} />);
 
+    // Deeplink opens directly on the GitHub tab with the URL prefilled.
     const input = screen.getByPlaceholderText(/github\.com/i) as HTMLInputElement;
     expect(input.value).toBe(url);
     await waitFor(() => expect(screen.getByText(/Will import/i)).toBeTruthy());
     expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy();
+    // Model name (from index.md frontmatter) and the object list are shown.
+    expect(screen.getByText(/Demo Project/i)).toBeTruthy();
+    expect(screen.getByText(/^Orders$/i)).toBeTruthy();
     // Deeplink previews the bundle but never auto-applies it — Import stays a
     // manual, deliberate click.
     expect(onConfirm).not.toHaveBeenCalled();

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -70,11 +70,33 @@ describe("ImportDialog UI", () => {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("ImportDialog GitHub URL import", () => {
-  it("renders the GitHub URL input on the GitHub tab", () => {
+  it("renders the GitHub URL input on the GitHub tab (no Fetch button — it auto-loads)", () => {
     render(<ImportDialog onConfirm={() => {}} onClose={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /from github/i }));
     expect(screen.getByPlaceholderText(/github\.com/i)).toBeTruthy();
-    expect(screen.getByRole("button", { name: /^fetch$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^fetch$/i })).toBeNull();
+  });
+
+  it("auto-fetches on paste (no button click needed)", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
+    vi.stubGlobal("fetch", vi.fn(async (u: string) => {
+      const bodies: Record<string, string> = {
+        [base + "index.md"]: "---\ntitle: Demo Project\n---\n[Orders](./orders.md)",
+        [base + "orders.md"]: "---\ntitle: Orders\ntype: OWOX Data Mart\n---\n\n## Schema\n\n- id INTEGER\n",
+      };
+      const body = bodies[u];
+      return { ok: body != null, status: body != null ? 200 : 404, text: async () => body ?? "" } as Response;
+    }));
+
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /from github/i }));
+    const input = screen.getByPlaceholderText(/github\.com/i) as HTMLInputElement;
+    const url = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
+    // Simulate a paste: value is set, then the paste handler fires.
+    input.value = url;
+    fireEvent.paste(input);
+    await waitFor(() => expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy());
+    expect(screen.getByText(/Demo Project/i)).toBeTruthy();
   });
 
   it("opens the GitHub tab, prefills, auto-fetches, and previews the model (name + objects) when initialUrl is given", async () => {

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -75,11 +75,15 @@ describe("ImportDialog GitHub URL import", () => {
     }));
 
     const url = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
-    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} initialUrl={url} />);
+    const onConfirm = vi.fn();
+    render(<ImportDialog onConfirm={onConfirm} onClose={() => {}} initialUrl={url} />);
 
     const input = screen.getByPlaceholderText(/github\.com/i) as HTMLInputElement;
     expect(input.value).toBe(url);
     await waitFor(() => expect(screen.getByText(/Will import/i)).toBeTruthy());
     expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy();
+    // Deeplink previews the bundle but never auto-applies it — Import stays a
+    // manual, deliberate click.
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -104,4 +104,34 @@ describe("ImportDialog GitHub URL import", () => {
     // manual, deliberate click.
     expect(onConfirm).not.toHaveBeenCalled();
   });
+
+  it("keeps each tab autonomous: the GitHub preview does not show on other tabs", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      const bodies: Record<string, string> = {
+        [base + "index.md"]: "---\ntitle: Demo Project\n---\n[Orders](./orders.md)",
+        [base + "orders.md"]: "---\ntitle: Orders\ntype: OWOX Data Mart\n---\n\n## Schema\n\n- id INTEGER\n",
+      };
+      const body = bodies[url];
+      return { ok: body != null, status: body != null ? 200 : 404, text: async () => body ?? "" } as Response;
+    }));
+
+    const url = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} initialUrl={url} />);
+
+    // GitHub tab shows the preview and an enabled Import button.
+    await waitFor(() => expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy());
+    expect((screen.getByRole("button", { name: /^import$/i }) as HTMLButtonElement).disabled).toBe(false);
+
+    // Switching to the Upload tab (no input there) hides the preview and
+    // disables Import — the fetched model belongs to the GitHub tab only.
+    fireEvent.click(screen.getByRole("button", { name: /upload files/i }));
+    await waitFor(() => expect(screen.queryByText(/Will import/i)).toBeNull());
+    expect(screen.queryByText(/Demo Project/i)).toBeNull();
+    expect((screen.getByRole("button", { name: /^import$/i }) as HTMLButtonElement).disabled).toBe(true);
+
+    // Switching back restores the GitHub tab's own preview.
+    fireEvent.click(screen.getByRole("button", { name: /from github/i }));
+    await waitFor(() => expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy());
+  });
 });

--- a/packages/web/src/components/ImportDialog.test.tsx
+++ b/packages/web/src/components/ImportDialog.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { strFromU8, unzipSync } from "fflate";
 import { bundleToZip, filesToGraph } from "../okf/io";
@@ -51,5 +51,35 @@ describe("ImportDialog UI", () => {
     expect(graph.nodes.map((n: { title: string }) => n.title)).toContain("Customers");
     expect(graph.nodes[0].status).toBe("pending");
     expect(mode).toBe("merge");
+  });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ImportDialog GitHub URL import", () => {
+  it("renders the GitHub URL input", () => {
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} />);
+    expect(screen.getByPlaceholderText(/github\.com/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /fetch/i })).toBeTruthy();
+  });
+
+  it("prefills and auto-fetches when initialUrl is given, then previews the bundle", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      const bodies: Record<string, string> = {
+        [base + "index.md"]: "[Orders](./orders.md)",
+        [base + "orders.md"]: "---\ntitle: Orders\ntype: OWOX Data Mart\n---\n\n## Schema\n\n- id INTEGER\n",
+      };
+      const body = bodies[url];
+      return { ok: body != null, status: body != null ? 200 : 404, text: async () => body ?? "" } as Response;
+    }));
+
+    const url = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
+    render(<ImportDialog onConfirm={() => {}} onClose={() => {}} initialUrl={url} />);
+
+    const input = screen.getByPlaceholderText(/github\.com/i) as HTMLInputElement;
+    expect(input.value).toBe(url);
+    await waitFor(() => expect(screen.getByText(/Will import/i)).toBeTruthy());
+    expect(screen.getByText(/Will import 1 marts/i)).toBeTruthy();
   });
 });

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -295,12 +295,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl, hasExistingModel 
                 {preview.nodes.map(n => (
                   <div key={n.key} className="flex items-center justify-between gap-2 px-2.5 py-1.5">
                     <span className="truncate text-[12.5px] text-slate-800">{n.title}</span>
-                    <span className="flex items-center gap-2 shrink-0">
-                      <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-slate-500">
-                        {n.inputSource}
-                      </span>
-                      <span className="text-[11px] text-slate-400">{n.schema.length} fields</span>
-                    </span>
+                    <span className="shrink-0 text-[11px] text-slate-400">{n.schema.length} fields</span>
                   </div>
                 ))}
               </div>

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -17,9 +17,13 @@ interface ImportDialogProps {
   /** When set (from a `?okf=` deeplink), open the GitHub tab, prefill the URL,
    *  and auto-fetch on mount so the preview is ready. */
   initialUrl?: string;
+  /** Whether the canvas already holds a model. When false (e.g. a first-time
+   *  visitor via deeplink), the Replace/Merge choice is meaningless and hidden;
+   *  the import just populates the empty canvas. */
+  hasExistingModel?: boolean;
 }
 
-export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogProps) {
+export function ImportDialog({ onConfirm, onClose, initialUrl, hasExistingModel = false }: ImportDialogProps) {
   const [activeTab, setActiveTab] = useState<TabId>(initialUrl ? "github" : "upload");
   const [pasteText, setPasteText] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -301,13 +305,20 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
                 ))}
               </div>
             )}
-            <span className="text-[12px] font-medium text-slate-500 mt-1">When applying to the canvas</span>
-            {(["replace", "merge"] as const).map(m => (
-              <label key={m} className="flex items-center gap-2 text-[13px] text-slate-800 cursor-pointer">
-                <input type="radio" name="okf-mode" checked={mode === m} onChange={() => setMode(m)} />
-                {m === "replace" ? "Replace the canvas" : "Merge into the canvas"}
-              </label>
-            ))}
+            {/* The Replace/Merge choice only makes sense when there's already a
+                model on the canvas — a first-time visitor lands on an empty
+                canvas, so the import simply populates it. */}
+            {hasExistingModel && (
+              <>
+                <span className="text-[12px] font-medium text-slate-500 mt-1">When applying to the canvas</span>
+                {(["replace", "merge"] as const).map(m => (
+                  <label key={m} className="flex items-center gap-2 text-[13px] text-slate-800 cursor-pointer">
+                    <input type="radio" name="okf-mode" checked={mode === m} onChange={() => setMode(m)} />
+                    {m === "replace" ? "Replace the canvas" : "Merge into the canvas"}
+                  </label>
+                ))}
+              </>
+            )}
             <p className="text-[12px] text-slate-500">
               Will import {preview.nodes.length} marts, {preview.edges.length} relationships.
             </p>

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -1,20 +1,27 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { filesToGraph, parsePastedMarkdown, zipToFiles } from "../okf/io";
+import { fetchOkfBundleFromUrl } from "../okf/github";
 import type { ModelGraph } from "@mc/okf";
 
 interface ImportDialogProps {
   onConfirm: (graph: ModelGraph, mode: "replace" | "merge") => void;
   onClose: () => void;
+  /** When set (from a `?okf=` deeplink), prefill the GitHub URL field and
+   *  auto-fetch on mount so the preview is ready. */
+  initialUrl?: string;
 }
 
-export function ImportDialog({ onConfirm, onClose }: ImportDialogProps) {
+export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogProps) {
   const [pasteText, setPasteText] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<ModelGraph | null>(null);
   const [mode, setMode] = useState<"replace" | "merge">("replace");
   const [copied, setCopied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [url, setUrl] = useState(initialUrl ?? "");
+  const [fetching, setFetching] = useState(false);
+  const [fetchedFiles, setFetchedFiles] = useState<Record<string, string> | null>(null);
 
   // Copy the AI authoring guide to the clipboard so the user can paste it into
   // Claude/ChatGPT to generate an importable OKF model. Falls back to opening
@@ -31,9 +38,10 @@ export function ImportDialog({ onConfirm, onClose }: ImportDialogProps) {
   }
 
   // Parse the current inputs into a ModelGraph (pending nodes — OKF carries no
-  // OWOX identity). Throws on empty/invalid input.
-  async function buildGraph(paste: string): Promise<ModelGraph> {
-    let files: Record<string, string> = {};
+  // OWOX identity). Merges three sources: fetched-from-URL, uploaded files, and
+  // pasted markdown. Throws on empty/invalid input.
+  async function buildGraph(paste: string, fetched: Record<string, string> | null): Promise<ModelGraph> {
+    let files: Record<string, string> = { ...(fetched ?? {}) };
     const uploaded = fileInputRef.current?.files;
     if (uploaded && uploaded.length > 0) {
       for (const file of Array.from(uploaded)) {
@@ -45,19 +53,46 @@ export function ImportDialog({ onConfirm, onClose }: ImportDialogProps) {
       }
     }
     if (paste.trim()) files = { ...files, ...parsePastedMarkdown(paste.trim()) };
-    if (Object.keys(files).length === 0) throw new Error("Provide a file or paste markdown content.");
+    if (Object.keys(files).length === 0) throw new Error("Provide a file, paste markdown, or fetch from a URL.");
     const graph = filesToGraph(files);
     return { ...graph, nodes: graph.nodes.map(n => ({ ...n, status: "pending" as const, owoxId: null })) };
   }
 
   // Re-parse to drive the live preview/count. Empty input clears both; a parse
   // error is shown (and clears the preview) so the count never lies.
-  async function refresh(paste: string) {
-    const hasInput = (fileInputRef.current?.files?.length ?? 0) > 0 || paste.trim().length > 0;
+  async function refresh(paste: string, fetched: Record<string, string> | null = fetchedFiles) {
+    const hasInput =
+      (fileInputRef.current?.files?.length ?? 0) > 0 ||
+      paste.trim().length > 0 ||
+      (fetched != null && Object.keys(fetched).length > 0);
     if (!hasInput) { setPreview(null); setError(null); return; }
-    try { setPreview(await buildGraph(paste)); setError(null); }
+    try { setPreview(await buildGraph(paste, fetched)); setError(null); }
     catch (e) { setPreview(null); setError((e as Error).message ?? "Failed to parse OKF bundle."); }
   }
+
+  // Fetch a public OKF bundle from a GitHub URL and fold it into the preview.
+  async function fetchFromUrl(target: string) {
+    const trimmed = target.trim();
+    if (!trimmed) return;
+    setFetching(true); setError(null);
+    try {
+      const files = await fetchOkfBundleFromUrl(trimmed);
+      setFetchedFiles(files);
+      await refresh(pasteText, files);
+    } catch (e) {
+      setFetchedFiles(null);
+      setPreview(null);
+      setError((e as Error).message ?? "Failed to fetch bundle.");
+    } finally {
+      setFetching(false);
+    }
+  }
+
+  // Deeplink entry: prefill + auto-fetch once on mount.
+  useEffect(() => {
+    if (initialUrl) void fetchFromUrl(initialUrl);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     /* Backdrop */
@@ -112,6 +147,34 @@ export function ImportDialog({ onConfirm, onClose }: ImportDialogProps) {
             onChange={() => void refresh(pasteText)}
             className="block w-full text-[13px] text-slate-600 file:mr-3 file:py-1 file:px-3 file:rounded-md file:border file:border-[#d8dee8] file:bg-white file:text-[13px] file:font-medium file:cursor-pointer hover:file:bg-[#f1f3f7]"
           />
+        </div>
+
+        {/* Import from a public GitHub URL — fetches the bundle client-side from
+            raw.githubusercontent.com and folds it into the same preview. */}
+        <div>
+          <label className="block text-[13px] font-medium text-slate-700 mb-1">
+            Or import from a public GitHub URL
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void fetchFromUrl(url); } }}
+              placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
+              className="flex-1 min-w-0 text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
+            />
+            <button
+              onClick={() => void fetchFromUrl(url)}
+              disabled={!url.trim() || fetching}
+              className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-3 py-[7px] cursor-pointer hover:bg-[#f1f3f7] disabled:opacity-50 whitespace-nowrap"
+            >
+              {fetching ? "Fetching…" : "Fetch"}
+            </button>
+          </div>
+          <p className="mt-1 text-[12px] text-slate-500">
+            Paste a link to an OKF bundle folder. Works with any public GitHub repo in the OKF format (like OWOX/models).
+          </p>
         </div>
 
         {/* Paste area */}

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -2,20 +2,29 @@ import { useEffect, useRef, useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { filesToGraph, parsePastedMarkdown, zipToFiles } from "../okf/io";
 import { fetchOkfBundleFromUrl } from "../okf/github";
-import type { ModelGraph } from "@mc/okf";
+import { parseFrontmatter, type ModelGraph } from "@mc/okf";
+
+type TabId = "upload" | "paste" | "github";
+const TABS: { id: TabId; label: string }[] = [
+  { id: "upload", label: "Upload files" },
+  { id: "paste", label: "Paste markdown" },
+  { id: "github", label: "From GitHub" },
+];
 
 interface ImportDialogProps {
   onConfirm: (graph: ModelGraph, mode: "replace" | "merge") => void;
   onClose: () => void;
-  /** When set (from a `?okf=` deeplink), prefill the GitHub URL field and
-   *  auto-fetch on mount so the preview is ready. */
+  /** When set (from a `?okf=` deeplink), open the GitHub tab, prefill the URL,
+   *  and auto-fetch on mount so the preview is ready. */
   initialUrl?: string;
 }
 
 export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogProps) {
+  const [activeTab, setActiveTab] = useState<TabId>(initialUrl ? "github" : "upload");
   const [pasteText, setPasteText] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<ModelGraph | null>(null);
+  const [modelName, setModelName] = useState<string | null>(null);
   const [mode, setMode] = useState<"replace" | "merge">("replace");
   const [copied, setCopied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -37,10 +46,9 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     }
   }
 
-  // Parse the current inputs into a ModelGraph (pending nodes — OKF carries no
-  // OWOX identity). Merges three sources: fetched-from-URL, uploaded files, and
-  // pasted markdown. Throws on empty/invalid input.
-  async function buildGraph(paste: string, fetched: Record<string, string> | null): Promise<ModelGraph> {
+  // Merge the three input sources (fetched-from-URL, uploaded files, pasted
+  // markdown) into one path→content map.
+  async function collectFiles(paste: string, fetched: Record<string, string> | null): Promise<Record<string, string>> {
     let files: Record<string, string> = { ...(fetched ?? {}) };
     const uploaded = fileInputRef.current?.files;
     if (uploaded && uploaded.length > 0) {
@@ -53,21 +61,45 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
       }
     }
     if (paste.trim()) files = { ...files, ...parsePastedMarkdown(paste.trim()) };
-    if (Object.keys(files).length === 0) throw new Error("Provide a file, paste markdown, or fetch from a URL.");
+    return files;
+  }
+
+  // Parse into a ModelGraph with pending nodes (OKF carries no OWOX identity).
+  function toPendingGraph(files: Record<string, string>): ModelGraph {
     const graph = filesToGraph(files);
     return { ...graph, nodes: graph.nodes.map(n => ({ ...n, status: "pending" as const, owoxId: null })) };
   }
 
-  // Re-parse to drive the live preview/count. Empty input clears both; a parse
+  // Model name from the bundle's index.md frontmatter title, when present.
+  function modelNameOf(files: Record<string, string>): string | null {
+    const idx = Object.entries(files).find(([p]) => p.toLowerCase().endsWith("index.md"));
+    if (!idx) return null;
+    try {
+      const t = parseFrontmatter(idx[1]).data.title;
+      return typeof t === "string" && t.trim() ? t.trim() : null;
+    } catch {
+      return null;
+    }
+  }
+
+  // Re-parse to drive the live preview/count. Empty input clears it; a parse
   // error is shown (and clears the preview) so the count never lies.
   async function refresh(paste: string, fetched: Record<string, string> | null = fetchedFiles) {
     const hasInput =
       (fileInputRef.current?.files?.length ?? 0) > 0 ||
       paste.trim().length > 0 ||
       (fetched != null && Object.keys(fetched).length > 0);
-    if (!hasInput) { setPreview(null); setError(null); return; }
-    try { setPreview(await buildGraph(paste, fetched)); setError(null); }
-    catch (e) { setPreview(null); setError((e as Error).message ?? "Failed to parse OKF bundle."); }
+    if (!hasInput) { setPreview(null); setModelName(null); setError(null); return; }
+    try {
+      const files = await collectFiles(paste, fetched);
+      if (Object.keys(files).length === 0) { setPreview(null); setModelName(null); setError(null); return; }
+      setPreview(toPendingGraph(files));
+      setModelName(modelNameOf(files));
+      setError(null);
+    } catch (e) {
+      setPreview(null); setModelName(null);
+      setError((e as Error).message ?? "Failed to parse OKF bundle.");
+    }
   }
 
   // Fetch a public OKF bundle from a GitHub URL and fold it into the preview.
@@ -81,18 +113,41 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
       await refresh(pasteText, files);
     } catch (e) {
       setFetchedFiles(null);
-      setPreview(null);
+      setPreview(null); setModelName(null);
       setError((e as Error).message ?? "Failed to fetch bundle.");
     } finally {
       setFetching(false);
     }
   }
 
-  // Deeplink entry: prefill + auto-fetch once on mount.
+  // Deeplink entry: prefill + auto-fetch once on mount (GitHub tab is active).
   useEffect(() => {
     if (initialUrl) void fetchFromUrl(initialUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // "No model yet? Generate one with AI" — shown on the upload & paste tabs.
+  const aiBlock = (
+    <div className="flex flex-col gap-1.5 rounded-lg border border-[#e6e9f0] bg-[#f7f8fa] px-3 py-2.5">
+      <span className="text-[12.5px] text-slate-600">No model yet? Generate one with AI:</span>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={copyInstructions}
+          className="flex items-center gap-[6px] rounded-lg bg-[#1e88e5] px-3 py-[6px] text-[12.5px] font-[550] text-white hover:bg-[#1976d2]"
+        >
+          {copied ? <><Check size={14} /> Copied — paste into Claude</> : <><Copy size={14} /> Copy AI instructions</>}
+        </button>
+        <a
+          href="/ai-instructions.html"
+          target="_blank"
+          rel="noopener"
+          className="text-[12.5px] text-[#1e88e5] hover:text-[#1976d2] underline underline-offset-2"
+        >
+          View guide ↗
+        </a>
+      </div>
+    </div>
+  );
 
   return (
     /* Backdrop */
@@ -111,85 +166,91 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
           </button>
         </div>
 
-        {/* Generate a model with AI: copy the authoring guide → paste into
-            Claude/ChatGPT. The raw guide also lives at /okf-format.md so an
-            assistant can fetch it directly. */}
-        <div className="-mt-1 flex flex-col gap-1.5 rounded-lg border border-[#e6e9f0] bg-[#f7f8fa] px-3 py-2.5">
-          <span className="text-[12.5px] text-slate-600">No model yet? Generate one with AI:</span>
-          <div className="flex flex-wrap items-center gap-3">
+        {/* Source tabs — segmented control (upload / paste / GitHub). */}
+        <div className="flex gap-1 rounded-lg bg-[#f1f3f7] p-1">
+          {TABS.map(t => (
             <button
-              onClick={copyInstructions}
-              className="flex items-center gap-[6px] rounded-lg bg-[#1e88e5] px-3 py-[6px] text-[12.5px] font-[550] text-white hover:bg-[#1976d2]"
+              key={t.id}
+              onClick={() => setActiveTab(t.id)}
+              className={
+                "flex-1 rounded-md px-3 py-[6px] text-[12.5px] font-[550] transition " +
+                (activeTab === t.id
+                  ? "bg-white text-slate-900 shadow-sm"
+                  : "text-slate-500 hover:text-slate-700")
+              }
             >
-              {copied ? <><Check size={14} /> Copied — paste into Claude</> : <><Copy size={14} /> Copy AI instructions</>}
+              {t.label}
             </button>
-            <a
-              href="/ai-instructions.html"
-              target="_blank"
-              rel="noopener"
-              className="text-[12.5px] text-[#1e88e5] hover:text-[#1976d2] underline underline-offset-2"
-            >
-              View guide ↗
-            </a>
+          ))}
+        </div>
+
+        {/* Upload tab */}
+        {activeTab === "upload" && (
+          <div className="flex flex-col gap-4">
+            {aiBlock}
+            <div>
+              <label className="block text-[13px] font-medium text-slate-700 mb-1">
+                Upload .md / .txt / .zip files
+              </label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md,.txt,.zip"
+                multiple
+                onChange={() => void refresh(pasteText)}
+                className="block w-full text-[13px] text-slate-600 file:mr-3 file:py-1 file:px-3 file:rounded-md file:border file:border-[#d8dee8] file:bg-white file:text-[13px] file:font-medium file:cursor-pointer hover:file:bg-[#f1f3f7]"
+              />
+            </div>
           </div>
-        </div>
+        )}
 
-        {/* File upload */}
-        <div>
-          <label className="block text-[13px] font-medium text-slate-700 mb-1">
-            Upload .md / .txt / .zip files
-          </label>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".md,.txt,.zip"
-            multiple
-            onChange={() => void refresh(pasteText)}
-            className="block w-full text-[13px] text-slate-600 file:mr-3 file:py-1 file:px-3 file:rounded-md file:border file:border-[#d8dee8] file:bg-white file:text-[13px] file:font-medium file:cursor-pointer hover:file:bg-[#f1f3f7]"
-          />
-        </div>
-
-        {/* Import from a public GitHub URL — fetches the bundle client-side from
-            raw.githubusercontent.com and folds it into the same preview. */}
-        <div>
-          <label className="block text-[13px] font-medium text-slate-700 mb-1">
-            Or import from a public GitHub URL
-          </label>
-          <div className="flex gap-2">
-            <input
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (fetching) return; void fetchFromUrl(url); } }}
-              placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
-              className="flex-1 min-w-0 text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
-            />
-            <button
-              onClick={() => void fetchFromUrl(url)}
-              disabled={!url.trim() || fetching}
-              className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-3 py-[7px] cursor-pointer hover:bg-[#f1f3f7] disabled:opacity-50 whitespace-nowrap"
-            >
-              {fetching ? "Fetching…" : "Fetch"}
-            </button>
+        {/* Paste tab */}
+        {activeTab === "paste" && (
+          <div className="flex flex-col gap-4">
+            {aiBlock}
+            <div>
+              <label className="block text-[13px] font-medium text-slate-700 mb-1">
+                Paste markdown content
+              </label>
+              <textarea
+                value={pasteText}
+                onChange={(e) => { setPasteText(e.target.value); void refresh(e.target.value); }}
+                placeholder={"<!-- path/to/file.md -->\n...content..."}
+                rows={6}
+                className="w-full text-[13px] font-mono border border-[#d8dee8] rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
+              />
+            </div>
           </div>
-          <p className="mt-1 text-[12px] text-slate-500">
-            Paste a link to an OKF bundle folder. Works with any public GitHub repo in the OKF format (like OWOX/models).
-          </p>
-        </div>
+        )}
 
-        {/* Paste area */}
-        <div>
-          <label className="block text-[13px] font-medium text-slate-700 mb-1">
-            Or paste markdown content
-          </label>
-          <textarea
-            value={pasteText}
-            onChange={(e) => { setPasteText(e.target.value); void refresh(e.target.value); }}
-            placeholder={"<!-- path/to/file.md -->\n...content..."}
-            rows={6}
-            className="w-full text-[13px] font-mono border border-[#d8dee8] rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
-          />
-        </div>
+        {/* GitHub tab — fetches the bundle client-side from raw.githubusercontent.com. */}
+        {activeTab === "github" && (
+          <div>
+            <label className="block text-[13px] font-medium text-slate-700 mb-1">
+              Import from a public GitHub URL
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (fetching) return; void fetchFromUrl(url); } }}
+                placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
+                className="flex-1 min-w-0 text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
+              />
+              <button
+                onClick={() => void fetchFromUrl(url)}
+                disabled={!url.trim() || fetching}
+                className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-3 py-[7px] cursor-pointer hover:bg-[#f1f3f7] disabled:opacity-50 whitespace-nowrap"
+              >
+                {fetching ? "Fetching…" : "Fetch"}
+              </button>
+            </div>
+            <p className="mt-1 text-[12px] text-slate-500">
+              Paste a link to an OKF bundle folder. Works with any public GitHub repo in the OKF format (like OWOX/models).
+            </p>
+          </div>
+        )}
 
         {error && (
           <p className="text-[13px] text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
@@ -197,10 +258,28 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
           </p>
         )}
 
-        {/* Apply mode + count — mirrors the OWOX-import dialog */}
+        {/* Preview: model name + object list + apply mode + count. */}
         {preview && (
-          <div className="flex flex-col gap-1.5 border-t border-slate-100 pt-3">
-            <span className="text-[12px] font-medium text-slate-500">When applying to the canvas</span>
+          <div className="flex flex-col gap-2 border-t border-slate-100 pt-3">
+            {modelName && (
+              <span className="text-[13px] font-semibold text-slate-900">{modelName}</span>
+            )}
+            {preview.nodes.length > 0 && (
+              <div className="max-h-40 overflow-y-auto rounded-lg border border-slate-100 divide-y divide-slate-50">
+                {preview.nodes.map(n => (
+                  <div key={n.key} className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+                    <span className="truncate text-[12.5px] text-slate-800">{n.title}</span>
+                    <span className="flex items-center gap-2 shrink-0">
+                      <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-slate-500">
+                        {n.inputSource}
+                      </span>
+                      <span className="text-[11px] text-slate-400">{n.schema.length} fields</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            <span className="text-[12px] font-medium text-slate-500 mt-1">When applying to the canvas</span>
             {(["replace", "merge"] as const).map(m => (
               <label key={m} className="flex items-center gap-2 text-[13px] text-slate-800 cursor-pointer">
                 <input type="radio" name="okf-mode" checked={mode === m} onChange={() => setMode(m)} />

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -46,22 +46,25 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     }
   }
 
-  // Merge the three input sources (fetched-from-URL, uploaded files, pasted
-  // markdown) into one path→content map.
-  async function collectFiles(paste: string, fetched: Record<string, string> | null): Promise<Record<string, string>> {
-    let files: Record<string, string> = { ...(fetched ?? {}) };
-    const uploaded = fileInputRef.current?.files;
-    if (uploaded && uploaded.length > 0) {
-      for (const file of Array.from(uploaded)) {
-        if (file.name.endsWith(".zip")) {
-          Object.assign(files, zipToFiles(new Uint8Array(await file.arrayBuffer())));
-        } else {
-          files[file.name] = await file.text();
+  // Collect the files for a single tab only — each tab is an autonomous source,
+  // so the preview reflects just the active tab's input (never a merge).
+  async function filesForTab(tab: TabId, paste: string, fetched: Record<string, string> | null): Promise<Record<string, string>> {
+    if (tab === "upload") {
+      const files: Record<string, string> = {};
+      const uploaded = fileInputRef.current?.files;
+      if (uploaded && uploaded.length > 0) {
+        for (const file of Array.from(uploaded)) {
+          if (file.name.endsWith(".zip")) {
+            Object.assign(files, zipToFiles(new Uint8Array(await file.arrayBuffer())));
+          } else {
+            files[file.name] = await file.text();
+          }
         }
       }
+      return files;
     }
-    if (paste.trim()) files = { ...files, ...parsePastedMarkdown(paste.trim()) };
-    return files;
+    if (tab === "paste") return paste.trim() ? parsePastedMarkdown(paste.trim()) : {};
+    return fetched ?? {}; // github
   }
 
   // Parse into a ModelGraph with pending nodes (OKF carries no OWOX identity).
@@ -82,17 +85,15 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     }
   }
 
-  // Re-parse to drive the live preview/count. Empty input clears it; a parse
-  // error is shown (and clears the preview) so the count never lies.
-  async function refresh(paste: string, fetched: Record<string, string> | null = fetchedFiles) {
-    const hasInput =
-      (fileInputRef.current?.files?.length ?? 0) > 0 ||
-      paste.trim().length > 0 ||
-      (fetched != null && Object.keys(fetched).length > 0);
-    if (!hasInput) { setPreview(null); setModelName(null); setError(null); return; }
+  // Re-parse the ACTIVE tab's source to drive the live preview/count. Empty
+  // input clears it; a parse error is shown (and clears the preview) so the
+  // count never lies. Only the active tab ever shows a preview + enabled Import.
+  async function refresh(tab: TabId, opts?: { paste?: string; fetched?: Record<string, string> | null }) {
+    const paste = opts?.paste ?? pasteText;
+    const fetched = opts?.fetched ?? fetchedFiles;
     try {
-      const files = await collectFiles(paste, fetched);
-      if (Object.keys(files).length === 0) { setPreview(null); setModelName(null); setError(null); return; }
+      const files = await filesForTab(tab, paste, fetched);
+      if (Object.keys(files).length === 0) { setPreview(null); setModelName(null); return; }
       setPreview(toPendingGraph(files));
       setModelName(modelNameOf(files));
       setError(null);
@@ -102,7 +103,15 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     }
   }
 
-  // Fetch a public OKF bundle from a GitHub URL and fold it into the preview.
+  // Switch tabs: each tab is autonomous, so clear any transient error and
+  // recompute the preview from the newly-active tab's own input.
+  function selectTab(tab: TabId) {
+    setActiveTab(tab);
+    setError(null);
+    void refresh(tab);
+  }
+
+  // Fetch a public OKF bundle from a GitHub URL into the GitHub tab's preview.
   async function fetchFromUrl(target: string) {
     const trimmed = target.trim();
     if (!trimmed) return;
@@ -110,7 +119,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     try {
       const files = await fetchOkfBundleFromUrl(trimmed);
       setFetchedFiles(files);
-      await refresh(pasteText, files);
+      await refresh("github", { fetched: files });
     } catch (e) {
       setFetchedFiles(null);
       setPreview(null); setModelName(null);
@@ -171,7 +180,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
           {TABS.map(t => (
             <button
               key={t.id}
-              onClick={() => setActiveTab(t.id)}
+              onClick={() => selectTab(t.id)}
               className={
                 "flex-1 rounded-md px-3 py-[6px] text-[12.5px] font-[550] transition " +
                 (activeTab === t.id
@@ -197,7 +206,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
                 type="file"
                 accept=".md,.txt,.zip"
                 multiple
-                onChange={() => void refresh(pasteText)}
+                onChange={() => void refresh("upload")}
                 className="block w-full text-[13px] text-slate-600 file:mr-3 file:py-1 file:px-3 file:rounded-md file:border file:border-[#d8dee8] file:bg-white file:text-[13px] file:font-medium file:cursor-pointer hover:file:bg-[#f1f3f7]"
               />
             </div>
@@ -214,7 +223,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
               </label>
               <textarea
                 value={pasteText}
-                onChange={(e) => { setPasteText(e.target.value); void refresh(e.target.value); }}
+                onChange={(e) => { setPasteText(e.target.value); void refresh("paste", { paste: e.target.value }); }}
                 placeholder={"<!-- path/to/file.md -->\n...content..."}
                 rows={6}
                 className="w-full text-[13px] font-mono border border-[#d8dee8] rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -102,7 +102,15 @@ export function ImportDialog({ onConfirm, onClose, initialUrl, hasExistingModel 
     try {
       const files = await filesForTab(tab, paste, fetched);
       if (Object.keys(files).length === 0) { setPreview(null); setModelName(null); return; }
-      setPreview(toPendingGraph(files));
+      const graph = toPendingGraph(files);
+      // Content fetched/provided but no marts parsed out (e.g. a URL to a folder
+      // whose index.md lists sub-bundles, not models). Nothing to import.
+      if (graph.nodes.length === 0) {
+        setPreview(null); setModelName(null);
+        setError("No OKF marts found here — check that this is a valid OKF bundle.");
+        return;
+      }
+      setPreview(graph);
       setModelName(modelNameOf(files));
       setError(null);
     } catch (e) {

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -160,7 +160,7 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
               type="url"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void fetchFromUrl(url); } }}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (fetching) return; void fetchFromUrl(url); } }}
               placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
               className="flex-1 min-w-0 text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
             />

--- a/packages/web/src/components/ImportDialog.tsx
+++ b/packages/web/src/components/ImportDialog.tsx
@@ -28,9 +28,13 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
   const [mode, setMode] = useState<"replace" | "merge">("replace");
   const [copied, setCopied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
   const [url, setUrl] = useState(initialUrl ?? "");
   const [fetching, setFetching] = useState(false);
   const [fetchedFiles, setFetchedFiles] = useState<Record<string, string> | null>(null);
+  // Last URL that fetched successfully — so a blur/paste re-trigger for the same
+  // already-loaded link is a no-op (but a failed URL can still be retried).
+  const lastFetchedRef = useRef<string | null>(null);
 
   // Copy the AI authoring guide to the clipboard so the user can paste it into
   // Claude/ChatGPT to generate an importable OKF model. Falls back to opening
@@ -112,15 +116,20 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
   }
 
   // Fetch a public OKF bundle from a GitHub URL into the GitHub tab's preview.
+  // Auto-triggered on paste / blur / Enter / deeplink — there is no Fetch button.
+  // Skips re-fetching a URL that already loaded; a failed URL can be retried.
   async function fetchFromUrl(target: string) {
     const trimmed = target.trim();
-    if (!trimmed) return;
+    if (!trimmed || fetching) return;
+    if (trimmed === lastFetchedRef.current && preview) return;
     setFetching(true); setError(null);
     try {
       const files = await fetchOkfBundleFromUrl(trimmed);
+      lastFetchedRef.current = trimmed;
       setFetchedFiles(files);
       await refresh("github", { fetched: files });
     } catch (e) {
+      lastFetchedRef.current = null;
       setFetchedFiles(null);
       setPreview(null); setModelName(null);
       setError((e as Error).message ?? "Failed to fetch bundle.");
@@ -134,6 +143,14 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
     if (initialUrl) void fetchFromUrl(initialUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Reveal the END of the URL (where the bundle/model name is) whenever it's set
+  // programmatically — deeplink prefill or paste — without disturbing active
+  // typing (a focused input already scrolls to the caret).
+  useEffect(() => {
+    const el = urlInputRef.current;
+    if (el && document.activeElement !== el) el.scrollLeft = el.scrollWidth;
+  }, [url]);
 
   // "No model yet? Generate one with AI" — shown on the upload & paste tabs.
   const aiBlock = (
@@ -238,25 +255,21 @@ export function ImportDialog({ onConfirm, onClose, initialUrl }: ImportDialogPro
             <label className="block text-[13px] font-medium text-slate-700 mb-1">
               Import from a public GitHub URL
             </label>
-            <div className="flex gap-2">
-              <input
-                type="url"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (fetching) return; void fetchFromUrl(url); } }}
-                placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
-                className="flex-1 min-w-0 text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
-              />
-              <button
-                onClick={() => void fetchFromUrl(url)}
-                disabled={!url.trim() || fetching}
-                className="text-[13px] font-[550] border border-[#d8dee8] bg-white text-slate-900 rounded-lg px-3 py-[7px] cursor-pointer hover:bg-[#f1f3f7] disabled:opacity-50 whitespace-nowrap"
-              >
-                {fetching ? "Fetching…" : "Fetch"}
-              </button>
-            </div>
+            <input
+              ref={urlInputRef}
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onPaste={(e) => { const el = e.currentTarget; setTimeout(() => { setUrl(el.value); void fetchFromUrl(el.value); }, 0); }}
+              onBlur={() => { if (url.trim()) void fetchFromUrl(url); }}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void fetchFromUrl(url); } }}
+              placeholder="https://github.com/OWOX/models/tree/main/bundles/demo-project"
+              className="w-full text-[13px] border border-[#d8dee8] rounded-lg px-3 py-[7px] focus:outline-none focus:ring-2 focus:ring-[#1e88e5]"
+            />
             <p className="mt-1 text-[12px] text-slate-500">
-              Paste a link to an OKF bundle folder. Works with any public GitHub repo in the OKF format (like OWOX/models).
+              {fetching
+                ? "Fetching bundle…"
+                : "Paste a link to an OKF bundle folder — it loads automatically. Works with any public GitHub repo in the OKF format (like OWOX/models)."}
             </p>
           </div>
         )}

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -32,6 +32,7 @@ import type { ModelNode, ModelEdge, ModelGraph } from "@mc/okf";
 import { graphToBundleFiles, downloadBundle } from "../../okf/io";
 import { buildShareUrl, readSharedModel, readSharedName, clearSharedModelFromUrl } from "../../share/url";
 import { readTemplateModel, clearTemplateFromUrl } from "../../lib/templateLink";
+import { readOkfImportUrl, clearOkfFromUrl } from "../../share/okfLink";
 import { exportCanvasSvg } from "../../share/exportImage";
 import { pushModel, pushPreview, type PushResult } from "../../sync/push";
 import { detachFromOwox } from "../../sync/detach";
@@ -111,6 +112,11 @@ if (sharedGraph) clearSharedModelFromUrl();
 // (empty) graph — so it stays true for the session. Gates the first-screen
 // "start" chooser: shown once for new visitors, never over an opened model.
 const isFirstVisit = !templateInitial && !sharedGraph && persistedGraph === undefined;
+
+// `?okf=<github-url>` opens the Import dialog pre-filled with a public bundle URL
+// (marketing CTA for individual models). Captured at module load; the actual
+// fetch is async, so CanvasInner opens the dialog on mount and clears the param.
+const okfImportUrl = readOkfImportUrl();
 
 // Map a loaded template (by its display name) to the closest Insight-Questions
 // niche, so opening the Business Goal dialog after a template can pre-pick it.
@@ -220,6 +226,16 @@ function CanvasInner() {
     persistRelLabelMode(mode);
   }, []);
   const [showImport, setShowImport] = useState(false);
+  // Deeplink: open Import pre-filled for a `?okf=` bundle URL, once, on mount.
+  const [okfInitialUrl, setOkfInitialUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (okfImportUrl) {
+      setOkfInitialUrl(okfImportUrl);
+      setShowImport(true);
+      clearOkfFromUrl();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [showOwoxImport, setShowOwoxImport] = useState(false);
   const [showLibrary, setShowLibrary] = useState(false);
   // A template chosen from the library while the canvas already had content —
@@ -813,8 +829,9 @@ function CanvasInner() {
       )}
       {showImport && (
         <ImportDialog
+          initialUrl={okfInitialUrl ?? undefined}
           onConfirm={handleImportConfirm}
-          onClose={() => setShowImport(false)}
+          onClose={() => { setShowImport(false); setOkfInitialUrl(null); }}
         />
       )}
       {showOwoxImport && (

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -831,6 +831,7 @@ function CanvasInner() {
       {showImport && (
         <ImportDialog
           initialUrl={okfInitialUrl ?? undefined}
+          hasExistingModel={graph.nodes.length > 0}
           onConfirm={handleImportConfirm}
           onClose={() => { setShowImport(false); setOkfInitialUrl(null); }}
         />

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -242,7 +242,7 @@ function CanvasInner() {
   // held until the user confirms Replace vs Merge in the TemplateApplyDialog.
   const [pendingTemplate, setPendingTemplate] = useState<{ graph: ModelGraph; name: string } | null>(null);
   // First-screen chooser — shown once to brand-new visitors (no persisted model).
-  const [showWelcome, setShowWelcome] = useState(isFirstVisit);
+  const [showWelcome, setShowWelcome] = useState(isFirstVisit && !okfImportUrl);
   const [pushing, setPushing] = useState(false);
   const [pushResult, setPushResult] = useState<PushResult | null>(null);
   const [shareToast, setShareToast] = useState<string | null>(null);
@@ -555,6 +555,7 @@ function CanvasInner() {
       store.set({ ...withLayout(g), storageId: store.get().storageId ?? g.storageId });
     }
     setShowImport(false);
+    setOkfInitialUrl(null);
   }, [withLayout, applyMergeWithLayout]);
 
   const handleOwoxImportConfirm = useCallback((g: ModelGraph, mode: "replace" | "merge") => {

--- a/packages/web/src/okf/github.test.ts
+++ b/packages/web/src/okf/github.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   parseGithubBundleUrl,
   isAllowedGithubHost,
   rawDirBase,
   rawFileUrl,
   OkfFetchError,
+  extractMdLinks,
+  fetchOkfBundleFromUrl,
 } from "./github";
 
 describe("parseGithubBundleUrl", () => {
@@ -77,5 +79,62 @@ describe("rawDirBase / rawFileUrl", () => {
   it("preserves percent-encoded reserved chars in a filename (e.g. %23 stays encoded, not a literal #)", () => {
     const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/x/notes%231.md");
     expect(rawFileUrl(r).endsWith("notes%231.md")).toBe(true);
+  });
+});
+
+describe("extractMdLinks", () => {
+  it("extracts relative .md links, strips ./, dedupes, drops index.md and externals", () => {
+    const md = [
+      "| [Orders](./orders.md) | VIEW |",
+      "| [Customers](customers.md) | SQL |",
+      "| [Orders again](./orders.md) | VIEW |",
+      "| [Self](./index.md) | INDEX |",
+      "| [External](https://example.com/x.md) | X |",
+      "| [Docs](../readme.md) | X |",
+    ].join("\n");
+    expect(extractMdLinks(md).sort()).toEqual(["../readme.md", "customers.md", "orders.md"].sort());
+  });
+
+  it("returns an empty array when there are no md links", () => {
+    expect(extractMdLinks("# Title\n\nNo links here.")).toEqual([]);
+  });
+});
+
+describe("fetchOkfBundleFromUrl", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const mockFetch = (map: Record<string, { status?: number; body: string }>) => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      const hit = map[url];
+      if (!hit) return { ok: false, status: 404, text: async () => "not found" } as Response;
+      const status = hit.status ?? 200;
+      return { ok: status >= 200 && status < 300, status, text: async () => hit.body, json: async () => JSON.parse(hit.body) } as Response;
+    }));
+  };
+
+  it("fetches index.md then all linked files (raw, no API)", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/";
+    mockFetch({
+      [base + "index.md"]: { body: "[Orders](./orders.md)\n[Customers](./customers.md)" },
+      [base + "orders.md"]: { body: "# orders" },
+      [base + "customers.md"]: { body: "# customers" },
+    });
+    const files = await fetchOkfBundleFromUrl("https://github.com/OWOX/models/tree/main/bundles/demo-project");
+    expect(Object.keys(files).sort()).toEqual(["customers.md", "index.md", "orders.md"]);
+    expect(files["orders.md"]).toBe("# orders");
+  });
+
+  it("fetches a single .md file ref alone", async () => {
+    const raw = "https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/orders.md";
+    mockFetch({ [raw]: { body: "# just orders" } });
+    const files = await fetchOkfBundleFromUrl("https://github.com/OWOX/models/blob/main/bundles/demo-project/orders.md");
+    expect(files).toEqual({ "orders.md": "# just orders" });
+  });
+
+  it("throws a friendly error on 404", async () => {
+    mockFetch({}); // everything 404s
+    await expect(
+      fetchOkfBundleFromUrl("https://raw.githubusercontent.com/OWOX/models/main/bundles/x/orders.md"),
+    ).rejects.toThrow(/public/i);
   });
 });

--- a/packages/web/src/okf/github.test.ts
+++ b/packages/web/src/okf/github.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGithubBundleUrl,
+  isAllowedGithubHost,
+  rawDirBase,
+  rawFileUrl,
+  OkfFetchError,
+} from "./github";
+
+describe("parseGithubBundleUrl", () => {
+  it("parses a github tree (directory) URL", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/tree/main/bundles/demo-project");
+    expect(r).toEqual({ owner: "OWOX", repo: "models", ref: "main", path: "bundles/demo-project", kind: "dir" });
+  });
+
+  it("parses a github blob (.md file) URL as a file", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/demo-project/orders.md");
+    expect(r).toEqual({ owner: "OWOX", repo: "models", ref: "main", path: "bundles/demo-project/orders.md", kind: "file" });
+  });
+
+  it("parses a raw.githubusercontent.com URL", () => {
+    const r = parseGithubBundleUrl("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/index.md");
+    expect(r).toEqual({ owner: "OWOX", repo: "models", ref: "main", path: "bundles/demo-project/index.md", kind: "file" });
+  });
+
+  it("treats a bare repo root as a directory with empty path", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models");
+    expect(r).toEqual({ owner: "OWOX", repo: "models", ref: "HEAD", path: "", kind: "dir" });
+  });
+
+  it("strips a trailing slash on a tree URL", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/tree/main/bundles/demo-project/");
+    expect(r.path).toBe("bundles/demo-project");
+    expect(r.kind).toBe("dir");
+  });
+
+  it("rejects a non-GitHub host", () => {
+    expect(() => parseGithubBundleUrl("https://evil.com/OWOX/models")).toThrow(OkfFetchError);
+  });
+
+  it("rejects a malformed URL", () => {
+    expect(() => parseGithubBundleUrl("not a url")).toThrow(OkfFetchError);
+  });
+});
+
+describe("isAllowedGithubHost", () => {
+  it("accepts github + raw hosts, rejects others", () => {
+    expect(isAllowedGithubHost("https://github.com/x/y")).toBe(true);
+    expect(isAllowedGithubHost("https://raw.githubusercontent.com/x/y/main/z.md")).toBe(true);
+    expect(isAllowedGithubHost("https://gitlab.com/x/y")).toBe(false);
+    expect(isAllowedGithubHost("garbage")).toBe(false);
+  });
+});
+
+describe("rawDirBase / rawFileUrl", () => {
+  it("builds the raw directory base (trailing slash) for a dir ref", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/tree/main/bundles/demo-project");
+    expect(rawDirBase(r)).toBe("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/");
+  });
+
+  it("builds the raw dir base from a file ref by dropping the filename", () => {
+    const r = parseGithubBundleUrl("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/index.md");
+    expect(rawDirBase(r)).toBe("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/");
+  });
+
+  it("builds a raw file url", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/demo-project/orders.md");
+    expect(rawFileUrl(r)).toBe("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/orders.md");
+  });
+});

--- a/packages/web/src/okf/github.test.ts
+++ b/packages/web/src/okf/github.test.ts
@@ -41,6 +41,12 @@ describe("parseGithubBundleUrl", () => {
   it("rejects a malformed URL", () => {
     expect(() => parseGithubBundleUrl("not a url")).toThrow(OkfFetchError);
   });
+
+  it("does not throw on malformed percent-encoding in the path", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/x/bad%zz.md");
+    expect(r.kind).toBe("file");
+    expect(r.path.endsWith("bad%zz.md")).toBe(true);
+  });
 });
 
 describe("isAllowedGithubHost", () => {
@@ -66,5 +72,10 @@ describe("rawDirBase / rawFileUrl", () => {
   it("builds a raw file url", () => {
     const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/demo-project/orders.md");
     expect(rawFileUrl(r)).toBe("https://raw.githubusercontent.com/OWOX/models/main/bundles/demo-project/orders.md");
+  });
+
+  it("preserves percent-encoded reserved chars in a filename (e.g. %23 stays encoded, not a literal #)", () => {
+    const r = parseGithubBundleUrl("https://github.com/OWOX/models/blob/main/bundles/x/notes%231.md");
+    expect(rawFileUrl(r).endsWith("notes%231.md")).toBe(true);
   });
 });

--- a/packages/web/src/okf/github.test.ts
+++ b/packages/web/src/okf/github.test.ts
@@ -137,4 +137,28 @@ describe("fetchOkfBundleFromUrl", () => {
       fetchOkfBundleFromUrl("https://raw.githubusercontent.com/OWOX/models/main/bundles/x/orders.md"),
     ).rejects.toThrow(/public/i);
   });
+
+  it("rejects a bundle over the file cap", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/x/";
+    const links = Array.from({ length: 101 }, (_, i) => `[m${i}](./m${i}.md)`).join("\n");
+    mockFetch({ [base + "index.md"]: { body: links } });
+    await expect(
+      fetchOkfBundleFromUrl("https://github.com/OWOX/models/tree/main/bundles/x"),
+    ).rejects.toThrow(/too large/i);
+  });
+
+  it("falls back to the Contents API when there is no index.md", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/x/";
+    const api = "https://api.github.com/repos/OWOX/models/contents/bundles/x?ref=main";
+    mockFetch({
+      [api]: { body: JSON.stringify([
+        { name: "orders.md", type: "file" },
+        { name: "index.md", type: "file" },
+        { name: "sub", type: "dir" },
+      ]) },
+      [base + "orders.md"]: { body: "# orders" },
+    });
+    const files = await fetchOkfBundleFromUrl("https://github.com/OWOX/models/tree/main/bundles/x");
+    expect(files).toEqual({ "orders.md": "# orders" });
+  });
 });

--- a/packages/web/src/okf/github.test.ts
+++ b/packages/web/src/okf/github.test.ts
@@ -147,6 +147,21 @@ describe("fetchOkfBundleFromUrl", () => {
     ).rejects.toThrow(/too large/i);
   });
 
+  it("rejects (does not silently fall back) on a transient non-404 index.md failure", async () => {
+    const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/x/";
+    const api = "https://api.github.com/repos/OWOX/models/contents/bundles/x?ref=main";
+    mockFetch({
+      [base + "index.md"]: { status: 500, body: "server error" },
+      // If the (buggy) code fell back to the API, this would let the fallback
+      // succeed — so a passing test here proves we didn't take that path.
+      [api]: { body: JSON.stringify([{ name: "orders.md", type: "file" }]) },
+      [base + "orders.md"]: { body: "# orders" },
+    });
+    await expect(
+      fetchOkfBundleFromUrl("https://github.com/OWOX/models/tree/main/bundles/x"),
+    ).rejects.toThrow(/500/);
+  });
+
   it("falls back to the Contents API when there is no index.md", async () => {
     const base = "https://raw.githubusercontent.com/OWOX/models/main/bundles/x/";
     const api = "https://api.github.com/repos/OWOX/models/contents/bundles/x?ref=main";

--- a/packages/web/src/okf/github.ts
+++ b/packages/web/src/okf/github.ts
@@ -71,3 +71,95 @@ export function rawFileUrl(ref: GithubBundleRef): string {
   const segs = [ref.owner, ref.repo, ref.ref, ref.path].filter(Boolean);
   return `${RAW_HOST}/${segs.join("/")}`;
 }
+
+export const MAX_BUNDLE_FILES = 100;
+
+const NOT_FOUND = "Couldn't fetch. Make sure the repo is public and the URL points to an OKF bundle folder.";
+
+/** Extract relative `.md` targets from a markdown body (the bundle index). Skips
+ *  external (http/https) links, self-links to index.md, and anchors; strips a
+ *  leading `./`; dedupes. */
+export function extractMdLinks(indexMd: string): string[] {
+  const re = /\]\(\s*([^)\s]+?\.md)(?:#[^)]*)?\s*\)/gi;
+  const out = new Set<string>();
+  for (let m = re.exec(indexMd); m; m = re.exec(indexMd)) {
+    let p = m[1];
+    if (/^https?:/i.test(p)) continue;
+    p = p.replace(/^\.\//, "");
+    if (p === "index.md") continue;
+    out.add(p);
+  }
+  return [...out];
+}
+
+async function fetchText(url: string, signal?: AbortSignal): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetch(url, { signal });
+  } catch (e) {
+    if ((e as Error).name === "AbortError") throw e;
+    throw new OkfFetchError("Couldn't reach GitHub. Check the link and try again.");
+  }
+  if (res.status === 404) throw new OkfFetchError(NOT_FOUND);
+  if (!res.ok) throw new OkfFetchError(`GitHub returned ${res.status}. Try again.`);
+  return res.text();
+}
+
+// Fallback for bundles without an index.md: list the folder via the Contents API
+// (CORS-enabled). This path is subject to GitHub's 60 req/hour unauthenticated
+// limit, so index.md remains the primary route.
+async function listMdFilesViaApi(ref: GithubBundleRef, signal?: AbortSignal): Promise<string[]> {
+  const api = `https://api.github.com/repos/${ref.owner}/${ref.repo}/contents/${ref.path}?ref=${encodeURIComponent(ref.ref)}`;
+  let res: Response;
+  try {
+    res = await fetch(api, { signal, headers: { Accept: "application/vnd.github+json" } });
+  } catch (e) {
+    if ((e as Error).name === "AbortError") throw e;
+    throw new OkfFetchError("Couldn't reach GitHub. Check the link and try again.");
+  }
+  if (res.status === 403) throw new OkfFetchError("GitHub rate limit hit — try again shortly, or use a bundle with an index.md.");
+  if (!res.ok) throw new OkfFetchError(NOT_FOUND);
+  const items = (await res.json()) as Array<{ name: string; type: string }>;
+  return items
+    .filter(i => i.type === "file" && i.name.toLowerCase().endsWith(".md") && i.name !== "index.md")
+    .map(i => i.name);
+}
+
+/** Fetch a public OKF bundle from GitHub into a `Record<path, content>` map ready
+ *  for `filesToGraph`. Single-file refs fetch just that file; folder refs fetch
+ *  index.md, then its linked files in parallel (Contents-API fallback if there is
+ *  no index.md). Throws `OkfFetchError` with a user-facing message on any failure. */
+export async function fetchOkfBundleFromUrl(
+  input: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<Record<string, string>> {
+  const ref = parseGithubBundleUrl(input);
+  const { signal } = opts;
+
+  if (ref.kind === "file") {
+    const content = await fetchText(rawFileUrl(ref), signal);
+    return { [ref.path.split("/").pop() as string]: content };
+  }
+
+  const base = rawDirBase(ref);
+  let index: string | null = null;
+  try {
+    index = await fetchText(base + "index.md", signal);
+  } catch (e) {
+    if ((e as Error).name === "AbortError") throw e;
+    index = null; // fall through to the API listing
+  }
+
+  const relPaths = index != null ? extractMdLinks(index) : await listMdFilesViaApi(ref, signal);
+
+  if (index == null && relPaths.length === 0) throw new OkfFetchError(NOT_FOUND);
+  if (relPaths.length + (index != null ? 1 : 0) > MAX_BUNDLE_FILES) {
+    throw new OkfFetchError(`Bundle too large (max ${MAX_BUNDLE_FILES} files).`);
+  }
+
+  const files: Record<string, string> = {};
+  if (index != null) files["index.md"] = index;
+  const contents = await Promise.all(relPaths.map(p => fetchText(base + p, signal)));
+  relPaths.forEach((p, i) => { files[p] = contents[i]; });
+  return files;
+}

--- a/packages/web/src/okf/github.ts
+++ b/packages/web/src/okf/github.ts
@@ -31,7 +31,11 @@ export function parseGithubBundleUrl(input: string): GithubBundleRef {
   try { u = new URL(input.trim()); } catch { throw new OkfFetchError("Enter a valid URL."); }
   if (!ALLOWED_HOSTS.has(u.host)) throw new OkfFetchError("Only public GitHub links are supported.");
 
-  const segs = u.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+  // Keep segments percent-encoded exactly as `pathname` gives them: decoding here
+  // (a) could throw on malformed escapes like "%zz" outside our try/catch, and
+  // (b) would lose encoding of reserved chars (e.g. "%23" -> "#") before we
+  // rejoin them into a raw URL, corrupting the fetch path.
+  const segs = u.pathname.split("/").filter(Boolean);
   const kindOf = (path: string): "dir" | "file" => (path.toLowerCase().endsWith(".md") ? "file" : "dir");
 
   if (u.host === "raw.githubusercontent.com") {

--- a/packages/web/src/okf/github.ts
+++ b/packages/web/src/okf/github.ts
@@ -17,7 +17,9 @@ export interface GithubBundleRef {
 
 /** All user-facing fetch/parse failures are thrown as this type so the dialog
  *  can render `err.message` verbatim. */
-export class OkfFetchError extends Error {}
+export class OkfFetchError extends Error {
+  status?: number;
+}
 
 export function isAllowedGithubHost(url: string): boolean {
   try { return ALLOWED_HOSTS.has(new URL(url).host); } catch { return false; }
@@ -100,7 +102,11 @@ async function fetchText(url: string, signal?: AbortSignal): Promise<string> {
     if ((e as Error).name === "AbortError") throw e;
     throw new OkfFetchError("Couldn't reach GitHub. Check the link and try again.");
   }
-  if (res.status === 404) throw new OkfFetchError(NOT_FOUND);
+  if (res.status === 404) {
+    const err = new OkfFetchError(NOT_FOUND);
+    err.status = 404;
+    throw err;
+  }
   if (!res.ok) throw new OkfFetchError(`GitHub returned ${res.status}. Try again.`);
   return res.text();
 }
@@ -147,7 +153,15 @@ export async function fetchOkfBundleFromUrl(
     index = await fetchText(base + "index.md", signal);
   } catch (e) {
     if ((e as Error).name === "AbortError") throw e;
-    index = null; // fall through to the API listing
+    // Only a genuine 404 (no index.md) falls through to the Contents-API
+    // fallback. Any other failure (transient 500/429, network error) is a real
+    // error and must surface — silently falling back would hit GitHub's
+    // 60/hour rate limit on a bundle that actually has an index.md.
+    if ((e as OkfFetchError).status === 404) {
+      index = null; // fall through to the API listing
+    } else {
+      throw e;
+    }
   }
 
   const relPaths = index != null ? extractMdLinks(index) : await listMdFilesViaApi(ref, signal);

--- a/packages/web/src/okf/github.ts
+++ b/packages/web/src/okf/github.ts
@@ -1,0 +1,69 @@
+// Fetch a public OKF bundle straight from GitHub. The bundle's index.md lists
+// every model file, so we read index.md from raw.githubusercontent.com, extract
+// its relative .md links, and fetch them in parallel — no GitHub API, no
+// 60/hour rate limit. Everything runs in the browser; the only server change is
+// widening the CSP connect-src to allow the two GitHub hosts.
+
+const RAW_HOST = "https://raw.githubusercontent.com";
+const ALLOWED_HOSTS = new Set(["github.com", "www.github.com", "raw.githubusercontent.com"]);
+
+export interface GithubBundleRef {
+  owner: string;
+  repo: string;
+  ref: string;
+  path: string; // dir path (kind "dir") or file path (kind "file"); no leading/trailing slash
+  kind: "dir" | "file";
+}
+
+/** All user-facing fetch/parse failures are thrown as this type so the dialog
+ *  can render `err.message` verbatim. */
+export class OkfFetchError extends Error {}
+
+export function isAllowedGithubHost(url: string): boolean {
+  try { return ALLOWED_HOSTS.has(new URL(url).host); } catch { return false; }
+}
+
+/** Normalize any accepted GitHub URL form to a GithubBundleRef.
+ *  Accepts: github.com tree/blob URLs, a bare repo root, and
+ *  raw.githubusercontent.com URLs. `.md` targets are `kind: "file"`. */
+export function parseGithubBundleUrl(input: string): GithubBundleRef {
+  let u: URL;
+  try { u = new URL(input.trim()); } catch { throw new OkfFetchError("Enter a valid URL."); }
+  if (!ALLOWED_HOSTS.has(u.host)) throw new OkfFetchError("Only public GitHub links are supported.");
+
+  const segs = u.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+  const kindOf = (path: string): "dir" | "file" => (path.toLowerCase().endsWith(".md") ? "file" : "dir");
+
+  if (u.host === "raw.githubusercontent.com") {
+    // /{owner}/{repo}/{ref}/{...path}  (ref may be "refs/heads/{branch}")
+    if (segs.length < 3) throw new OkfFetchError("That GitHub link doesn't point to a file or folder.");
+    const [owner, repo, ...rest] = segs;
+    let ref = rest[0];
+    let pathParts = rest.slice(1);
+    if (rest[0] === "refs" && rest[1] === "heads") { ref = rest[2]; pathParts = rest.slice(3); }
+    const path = pathParts.join("/");
+    return { owner, repo, ref, path, kind: kindOf(path) };
+  }
+
+  // github.com: /{owner}/{repo}[/(tree|blob)/{ref}/{...path}]
+  if (segs.length < 2) throw new OkfFetchError("That GitHub link doesn't point to a repo.");
+  const [owner, repo, marker, ref, ...pathParts] = segs;
+  if (!marker) return { owner, repo, ref: "HEAD", path: "", kind: "dir" };
+  if (marker !== "tree" && marker !== "blob") throw new OkfFetchError("That GitHub link doesn't point to a file or folder.");
+  const path = pathParts.join("/");
+  return { owner, repo, ref: ref ?? "HEAD", path, kind: kindOf(path) };
+}
+
+/** Directory of the bundle, as a raw base URL with a trailing slash. For a file
+ *  ref, the filename is dropped so links resolve against the containing folder. */
+export function rawDirBase(ref: GithubBundleRef): string {
+  const dir = ref.kind === "file" ? ref.path.split("/").slice(0, -1).join("/") : ref.path;
+  const segs = [ref.owner, ref.repo, ref.ref, dir].filter(Boolean);
+  return `${RAW_HOST}/${segs.join("/")}/`;
+}
+
+/** Raw URL of a single file ref (meaningful only when kind === "file"). */
+export function rawFileUrl(ref: GithubBundleRef): string {
+  const segs = [ref.owner, ref.repo, ref.ref, ref.path].filter(Boolean);
+  return `${RAW_HOST}/${segs.join("/")}`;
+}

--- a/packages/web/src/share/okfLink.test.ts
+++ b/packages/web/src/share/okfLink.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readOkfImportUrl, clearOkfFromUrl, buildOkfDeeplink } from "./okfLink";
+
+const setUrl = (url: string) => history.replaceState(null, "", url);
+beforeEach(() => setUrl("/"));
+
+describe("readOkfImportUrl", () => {
+  it("returns a valid GitHub URL from ?okf=", () => {
+    const target = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
+    setUrl("/?okf=" + encodeURIComponent(target));
+    expect(readOkfImportUrl()).toBe(target);
+  });
+
+  it("returns null when the param is absent", () => {
+    setUrl("/?utm_source=x");
+    expect(readOkfImportUrl()).toBeNull();
+  });
+
+  it("returns null for a non-GitHub host (allowlist guard)", () => {
+    setUrl("/?okf=" + encodeURIComponent("https://evil.com/x/y"));
+    expect(readOkfImportUrl()).toBeNull();
+  });
+});
+
+describe("clearOkfFromUrl", () => {
+  it("removes only the okf param, preserving UTM params and the hash", () => {
+    setUrl("/?okf=" + encodeURIComponent("https://github.com/OWOX/models") + "&utm_source=news#m=abc");
+    clearOkfFromUrl();
+    expect(location.search).toBe("?utm_source=news");
+    expect(location.hash).toBe("#m=abc");
+  });
+});
+
+describe("buildOkfDeeplink", () => {
+  it("builds an origin-rooted ?okf= link with an encoded URL", () => {
+    const link = buildOkfDeeplink("https://github.com/OWOX/models/tree/main/bundles/saas");
+    expect(link).toBe(location.origin + "/?okf=" + encodeURIComponent("https://github.com/OWOX/models/tree/main/bundles/saas"));
+  });
+});

--- a/packages/web/src/share/okfLink.test.ts
+++ b/packages/web/src/share/okfLink.test.ts
@@ -5,9 +5,15 @@ const setUrl = (url: string) => history.replaceState(null, "", url);
 beforeEach(() => setUrl("/"));
 
 describe("readOkfImportUrl", () => {
-  it("returns a valid GitHub URL from ?okf=", () => {
+  it("returns a valid GitHub URL from ?okf= (percent-encoded)", () => {
     const target = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
     setUrl("/?okf=" + encodeURIComponent(target));
+    expect(readOkfImportUrl()).toBe(target);
+  });
+
+  it("returns a valid GitHub URL from a RAW (human-readable) ?okf=", () => {
+    const target = "https://github.com/OWOX/models/tree/main/bundles/demo-project";
+    setUrl("/?okf=" + target); // no encoding — the readable marketing form
     expect(readOkfImportUrl()).toBe(target);
   });
 
@@ -32,8 +38,17 @@ describe("clearOkfFromUrl", () => {
 });
 
 describe("buildOkfDeeplink", () => {
-  it("builds an origin-rooted ?okf= link with an encoded URL", () => {
-    const link = buildOkfDeeplink("https://github.com/OWOX/models/tree/main/bundles/saas");
-    expect(link).toBe(location.origin + "/?okf=" + encodeURIComponent("https://github.com/OWOX/models/tree/main/bundles/saas"));
+  it("builds an origin-rooted ?okf= link with a human-readable (raw) URL", () => {
+    const bundle = "https://github.com/OWOX/models/tree/main/bundles/saas";
+    const link = buildOkfDeeplink(bundle);
+    expect(link).toBe(location.origin + "/?okf=" + bundle); // `/` and `:` stay raw
+    // And it round-trips: readOkfImportUrl reads back the same URL.
+    history.replaceState(null, "", link);
+    expect(readOkfImportUrl()).toBe(bundle);
+  });
+
+  it("escapes only # and & so the query value can't break", () => {
+    const link = buildOkfDeeplink("https://github.com/o/r/tree/main/a&b#c");
+    expect(link).toBe(location.origin + "/?okf=https://github.com/o/r/tree/main/a%26b%23c");
   });
 });

--- a/packages/web/src/share/okfLink.ts
+++ b/packages/web/src/share/okfLink.ts
@@ -1,10 +1,13 @@
 import { isAllowedGithubHost } from "../okf/github";
 
-// Deep-link: `model.owox.com/?okf=<url-encoded github bundle url>` opens the
-// canvas with the Import dialog pre-filled and previewed for that bundle. It's
-// the marketing CTA target for individual public models (saas, ecommerce,
-// finance, …) hosted in the OWOX/models repo. An unknown/invalid URL is ignored
-// (the dialog just doesn't open), so the link degrades to a normal visit.
+// Deep-link: `model.owox.com/?okf=https://github.com/OWOX/models/tree/main/...`
+// opens the canvas with the Import dialog pre-filled and previewed for that
+// bundle. The bundle URL is kept human-readable in the address bar (`/` and `:`
+// stay raw) — a GitHub tree/blob URL has no `&`/`#`, so it parses cleanly as a
+// query value. It's the marketing CTA target for individual public models
+// (saas, ecommerce, finance, …) hosted in the OWOX/models repo. An
+// unknown/invalid URL is ignored (the dialog just doesn't open), so the link
+// degrades to a normal visit.
 
 const PARAM = "okf";
 
@@ -27,8 +30,11 @@ export function clearOkfFromUrl(): void {
   history.replaceState(null, "", location.pathname + (qs ? `?${qs}` : "") + location.hash);
 }
 
-/** Build a shareable deeplink for a public GitHub bundle URL (for marketing /
- *  internal use; no UI button ships this iteration). */
+/** Build a shareable, human-readable deeplink for a public GitHub bundle URL
+ *  (for marketing / internal use; no UI button ships this iteration). The URL is
+ *  left readable — only `#` and `&`, which would break query parsing, are
+ *  escaped; `/` and `:` stay raw. `okf` is the last param so nothing follows it. */
 export function buildOkfDeeplink(bundleUrl: string): string {
-  return `${location.origin}/?${PARAM}=${encodeURIComponent(bundleUrl)}`;
+  const readable = bundleUrl.replace(/#/g, "%23").replace(/&/g, "%26");
+  return `${location.origin}/?${PARAM}=${readable}`;
 }

--- a/packages/web/src/share/okfLink.ts
+++ b/packages/web/src/share/okfLink.ts
@@ -1,0 +1,34 @@
+import { isAllowedGithubHost } from "../okf/github";
+
+// Deep-link: `model.owox.com/?okf=<url-encoded github bundle url>` opens the
+// canvas with the Import dialog pre-filled and previewed for that bundle. It's
+// the marketing CTA target for individual public models (saas, ecommerce,
+// finance, …) hosted in the OWOX/models repo. An unknown/invalid URL is ignored
+// (the dialog just doesn't open), so the link degrades to a normal visit.
+
+const PARAM = "okf";
+
+/** Read `?okf=<url>` from the address bar. Returns the URL only if it points to
+ *  an allowed public GitHub host; otherwise null (missing param or bad host). */
+export function readOkfImportUrl(): string | null {
+  const raw = new URLSearchParams(location.search).get(PARAM);
+  if (!raw) return null;
+  return isAllowedGithubHost(raw) ? raw : null;
+}
+
+/** Strip the `okf` param after opening the dialog, so a refresh doesn't re-open
+ *  it. UTM params and the hash (a possible share link) are preserved — mirrors
+ *  clearTemplateFromUrl. No-ops when the param isn't present. */
+export function clearOkfFromUrl(): void {
+  const params = new URLSearchParams(location.search);
+  if (!params.has(PARAM)) return;
+  params.delete(PARAM);
+  const qs = params.toString();
+  history.replaceState(null, "", location.pathname + (qs ? `?${qs}` : "") + location.hash);
+}
+
+/** Build a shareable deeplink for a public GitHub bundle URL (for marketing /
+ *  internal use; no UI button ships this iteration). */
+export function buildOkfDeeplink(bundleUrl: string): string {
+  return `${location.origin}/?${PARAM}=${encodeURIComponent(bundleUrl)}`;
+}


### PR DESCRIPTION
## What

Lets users import an OKF bundle straight from a **public GitHub URL**, and gives marketing a shareable **`?okf=` deeplink** that opens the canvas with the bundle pre-loaded — so individual public models (saas, ecommerce, finance, …) from `OWOX/models` can be promoted via the canvas.

The Import dialog is reorganized into three **source tabs** — Upload files · Paste markdown · From GitHub — each autonomous, sharing one preview/apply flow.

## How it works

- **Fetch is client-side, index.md-driven.** Given a GitHub URL, we read the bundle's `index.md` from `raw.githubusercontent.com`, extract the relative `.md` links it lists, and fetch them in parallel — no GitHub API, no 60/hr rate limit. Contents-API fallback for bundles without an `index.md`. Host allowlist (`github.com` / `raw.githubusercontent.com` / `api.github.com`), 100-file cap, typed errors. The result feeds the existing `filesToGraph` funnel — no second apply path.
- **Deeplink** `model.owox.com/?okf=<github-url>` opens the GitHub tab pre-filled + auto-loaded. The URL stays human-readable (`/` and `:` unescaped); the reader accepts both raw and percent-encoded forms.
- **Server CSP** `connect-src` widened to the two GitHub hosts (client-side fetch to fixed hosts → no SSRF surface).

## UX details

- GitHub tab **auto-loads** on paste / blur / Enter / deeplink (no Fetch button); URL input scrolls to its end to keep the bundle name visible.
- Preview shows the **model name** (from `index.md`) + an object list (title · field count) + count.
- Each tab is **autonomous**: preview + enabled Import appear only on the tab that holds a model.
- **Replace/Merge** is shown only when the canvas already has a model (a first-time deeplink visitor lands on an empty canvas).
- Content that parses to **zero marts** is rejected with a clear message and a disabled Import.

## Tests

Unit coverage for URL parsing, index.md link extraction, fetch + fallback + file-cap, the `?okf=` reader/clear/builder (raw + encoded round-trip), and the dialog (tabs, autonomy, auto-fetch, empty-canvas apply-mode, zero-mart rejection). Full web suite green; `tsc && vite build` clean. Verified end-to-end against the real `OWOX/models/demo-project` bundle (28 files → 27 marts).

> Note: the demo bundle renders relationships without join keys — this is a **source-bundle limitation** (no PK markers / keyless joins), tracked separately for a proposal against `OWOX/models`, not a parser bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)