### PR TITLE
fix(web): push schema to LEGACY_GOOGLE_BIGQUERY storages

### DIFF
--- a/packages/web/src/sync/push.ts
+++ b/packages/web/src/sync/push.ts
@@ -30,10 +30,17 @@ export function pushPreview(graph: ModelGraph, storageId: string | null): { mart
   return { marts, relationships };
 }
 
-// OWOX validates the output schema with a storage-specific discriminator, e.g.
-// GOOGLE_BIGQUERY → "bigquery-data-mart-schema", SNOWFLAKE → "snowflake-data-mart-schema".
+// OWOX validates the output schema with a discriminator keyed on the storage
+// ENGINE, not its full type: GOOGLE_BIGQUERY and LEGACY_GOOGLE_BIGQUERY both use
+// "bigquery-data-mart-schema"; SNOWFLAKE → "snowflake-data-mart-schema". Strip
+// the vendor/legacy prefixes (LEGACY_ before GOOGLE_, so LEGACY_GOOGLE_BIGQUERY
+// collapses to "bigquery") to land on the engine name OWOX expects.
 function schemaDiscriminator(storageType: string): string {
-  const base = storageType.replace(/^GOOGLE_/, "").replace(/^AWS_/, "").toLowerCase();
+  const base = storageType
+    .replace(/^LEGACY_/, "")
+    .replace(/^GOOGLE_/, "")
+    .replace(/^AWS_/, "")
+    .toLowerCase();
   return `${base}-data-mart-schema`;
 }
 

--- a/packages/web/test/push.test.ts
+++ b/packages/web/test/push.test.ts
@@ -94,6 +94,26 @@ describe("pushModel", () => {
     expect(field).toMatchObject({ name: "id", alias: "user_id", description: "Unique id", isPrimaryKey: true });
   });
 
+  it("derives the schema discriminator by storage engine, stripping LEGACY_/GOOGLE_/AWS_ prefixes", async () => {
+    const cases: Array<[string, string]> = [
+      ["GOOGLE_BIGQUERY", "bigquery-data-mart-schema"],
+      ["LEGACY_GOOGLE_BIGQUERY", "bigquery-data-mart-schema"],
+      ["AWS_ATHENA", "athena-data-mart-schema"],
+    ];
+    for (const [storageType, expected] of cases) {
+      const s = createModelStore({ storageId: "stor_1" });
+      const n = s.addNode({ x: 0, y: 0 });
+      s.updateNode(n.key, { schema: [{ name: "id", type: "STRING", pk: true }] });
+      const bodies: Record<string, any> = {};
+      const apiMock = vi.fn(async (path: string, init?: any) => {
+        if (init?.body) bodies[path] = JSON.parse(init.body);
+        return { id: "owox_a" };
+      });
+      await pushModel(s, apiMock as any, storageType);
+      expect(bodies["/api/data-marts/owox_a/schema"].schema.type).toBe(expected);
+    }
+  });
+
   it("marks a node error on failure and counts it", async () => {
     const s = createModelStore({ storageId: "stor_1" }); s.addNode({ x: 0, y: 0 });
     const apiMock = vi.fn(async () => { throw new Error("boom"); });


### PR DESCRIPTION
## Problem

Push to OWOX created the marts, but the **field-schema push failed with 400** for every mart:

```
Failed to validate BigQuery schema: Invalid literal value, expected "bigquery-data-mart-schema"
```

## Root cause

The schema discriminator (`schema.type` in `PUT /api/data-marts/{id}/schema`) is keyed on the storage **engine**, not its full `type`. `schemaDiscriminator()` stripped only the `GOOGLE_`/`AWS_` prefixes, so a `LEGACY_GOOGLE_BIGQUERY` storage produced `legacy_google_bigquery-data-mart-schema`, which OWOX's Zod discriminated-union validator rejected.

Both BigQuery types — `GOOGLE_BIGQUERY` and `LEGACY_GOOGLE_BIGQUERY` — expect the same discriminator `bigquery-data-mart-schema` (the field-schema format for BigQuery is the same regardless of legacy). Mart creation itself still succeeded; only the separate schema PUT failed.

## Fix

Strip `^LEGACY_` before `^GOOGLE_`, so both types collapse to `bigquery-data-mart-schema`. Storage selection (`storageId` / UUID) is untouched — this is purely engine-name normalization for one payload field.

Verified live against a real mart:
- `type: "legacy_google_bigquery-data-mart-schema"` → **400**
- `type: "bigquery-data-mart-schema"` → **200** ✅

## Tests

A new test in `push.test.ts` covers the mapping for `GOOGLE_BIGQUERY`, `LEGACY_GOOGLE_BIGQUERY`, and `AWS_ATHENA` — locking in that no path is broken. All 16 tests in `push.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)