### PR TITLE
feat(web): Object labels — control object-node meta on the canvas

### DIFF
--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -26,6 +26,7 @@ import { createModelStore } from "../../state/model";
 import { loadPersistedGraph, persistGraph } from "../../state/persist";
 import { loadViewMode, persistViewMode, type ViewMode } from "../../state/viewMode";
 import { loadRelLabelMode, persistRelLabelMode, type RelLabelMode } from "../../state/relLabels";
+import { loadObjLabelMode, persistObjLabelMode, type ObjLabelMode } from "../../state/objLabels";
 import { loadModelName, persistModelName, DEFAULT_MODEL_NAME, templateModelName } from "../../state/modelName";
 import type { ModelNode, ModelEdge, ModelGraph } from "@mc/okf";
 
@@ -131,12 +132,12 @@ const TEMPLATE_NICHE: Record<string, string> = {
 };
 
 // ── helpers to convert between model and RF types ───────────────────────────
-function toRFNode(n: ModelNode, viewMode: ViewMode, keyFields?: string[]): Node {
+function toRFNode(n: ModelNode, viewMode: ViewMode, objLabelMode: ObjLabelMode, keyFields?: string[]): Node {
   return {
     id: n.key,
     type: "mart",
     position: n.position,
-    data: { ...n, _viewMode: viewMode, _keyFields: keyFields } as unknown as Record<string, unknown>,
+    data: { ...n, _viewMode: viewMode, _keyFields: keyFields, _objLabelMode: objLabelMode } as unknown as Record<string, unknown>,
   };
 }
 
@@ -224,6 +225,11 @@ function CanvasInner() {
   const handleRelLabelModeChange = useCallback((mode: RelLabelMode) => {
     setRelLabelMode(mode);
     persistRelLabelMode(mode);
+  }, []);
+  const [objLabelMode, setObjLabelMode] = useState<ObjLabelMode>(loadObjLabelMode());
+  const handleObjLabelModeChange = useCallback((mode: ObjLabelMode) => {
+    setObjLabelMode(mode);
+    persistObjLabelMode(mode);
   }, []);
   const [showImport, setShowImport] = useState(false);
   // Deeplink: open Import pre-filled for a `?okf=` bundle URL, once, on mount.
@@ -335,8 +341,8 @@ function CanvasInner() {
 
   useEffect(() => {
     const kf = keyFieldsByNode(graph.edges);
-    setRfNodes(graph.nodes.map(n => toRFNode(n, viewMode, [...(kf.get(n.key) ?? [])])));
-  }, [graph.nodes, graph.edges, viewMode, setRfNodes]);
+    setRfNodes(graph.nodes.map(n => toRFNode(n, viewMode, objLabelMode, [...(kf.get(n.key) ?? [])])));
+  }, [graph.nodes, graph.edges, viewMode, objLabelMode, setRfNodes]);
   useEffect(() => { setRfEdges(buildRfEdges(graph.edges, graph.nodes, viewMode, relLabelMode)); }, [graph.edges, graph.nodes, viewMode, relLabelMode, setRfEdges]);
 
   // Mark only the selected relationship as reconnectable so dragging an endpoint
@@ -936,7 +942,7 @@ function CanvasInner() {
         >
           {/* Tool dock — anchored to the canvas (not the outer row) so it sits
               just inside the canvas edge and slides over as the rail opens. */}
-          <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} onClear={() => setShowClear(true)} clearDisabled={graph.nodes.length === 0} relLabelMode={relLabelMode} onRelLabelModeChange={handleRelLabelModeChange} />
+          <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} onClear={() => setShowClear(true)} clearDisabled={graph.nodes.length === 0} relLabelMode={relLabelMode} onRelLabelModeChange={handleRelLabelModeChange} objLabelMode={objLabelMode} onObjLabelModeChange={handleObjLabelModeChange} />
           <ReactFlow
             nodes={rfNodes}
             edges={rfEdges}

--- a/packages/web/src/components/canvas/Dock.test.tsx
+++ b/packages/web/src/components/canvas/Dock.test.tsx
@@ -48,6 +48,44 @@ describe("Dock relationship-labels flyout", () => {
   });
 });
 
+describe("Dock object-labels flyout", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("opens the flyout 0.5s after hovering Add and lists all four modes", () => {
+    render(<Dock {...base} objLabelMode="all" onObjLabelModeChange={() => {}} />);
+    const add = screen.getByRole("button", { name: /add object/i });
+    fireEvent.mouseEnter(add.parentElement!);
+    expect(screen.queryByText("Show everything")).toBeNull(); // delay pending
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(screen.getByText("Show everything")).toBeTruthy();
+    expect(screen.getByText("Hide input source")).toBeTruthy();
+    expect(screen.getByText("Hide field count")).toBeTruthy();
+    expect(screen.getByText("Hide both")).toBeTruthy();
+  });
+
+  it("calls onObjLabelModeChange with the picked mode", () => {
+    const onPick = vi.fn();
+    render(<Dock {...base} objLabelMode="all" onObjLabelModeChange={onPick} />);
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /add object/i }).parentElement!);
+    act(() => { vi.advanceTimersByTime(500); });
+    fireEvent.click(screen.getByText("Hide both"));
+    expect(onPick).toHaveBeenCalledWith("both");
+  });
+
+  it("shows the glyph of the active mode as a badge", () => {
+    render(<Dock {...base} objLabelMode="noFields" onObjLabelModeChange={() => {}} />);
+    expect(screen.getByTestId("obj-label-badge").textContent).toBe("#");
+  });
+
+  it("still activates the Add tool when the button itself is clicked", () => {
+    const onToolChange = vi.fn();
+    render(<Dock {...base} onToolChange={onToolChange} objLabelMode="all" onObjLabelModeChange={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /add object/i }));
+    expect(onToolChange).toHaveBeenCalledWith("add");
+  });
+});
+
 describe("Dock ERD toggle", () => {
   it("renders the ERD toggle and fires onToggleView when clicked", () => {
     const onToggleView = vi.fn();

--- a/packages/web/src/components/canvas/Dock.tsx
+++ b/packages/web/src/components/canvas/Dock.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ViewMode } from "../../state/viewMode";
 import type { RelLabelMode } from "../../state/relLabels";
+import type { ObjLabelMode } from "../../state/objLabels";
 
 export type Tool = "select" | "add" | "connect" | "layout";
 
@@ -18,6 +19,20 @@ const REL_LABEL_OPTIONS: { mode: RelLabelMode; label: string; helper: string }[]
   { mode: "hidden", label: "Hide all labels", helper: "Just the connector lines — no keys, no cardinality" },
 ];
 
+const OBJ_LABEL_GLYPH: Record<ObjLabelMode, string> = {
+  all: "≡",
+  noSource: "⬚",
+  noFields: "#",
+  both: "⊘",
+};
+
+const OBJ_LABEL_OPTIONS: { mode: ObjLabelMode; label: string; helper: string }[] = [
+  { mode: "all", label: "Show everything", helper: "Input source and field count on every object" },
+  { mode: "noSource", label: "Hide input source", helper: "Hide the source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent" },
+  { mode: "noFields", label: "Hide field count", helper: "Hide the field-count line under each object" },
+  { mode: "both", label: "Hide both", helper: "Just the object title — no source badge, no field count" },
+];
+
 interface DockProps {
   activeTool: Tool;
   onToolChange: (tool: Tool) => void;
@@ -27,6 +42,8 @@ interface DockProps {
   clearDisabled?: boolean;
   relLabelMode?: RelLabelMode;
   onRelLabelModeChange?: (mode: RelLabelMode) => void;
+  objLabelMode?: ObjLabelMode;
+  onObjLabelModeChange?: (mode: ObjLabelMode) => void;
 }
 
 const SelectIcon = () => (
@@ -203,7 +220,96 @@ function ConnectToolButton({
   );
 }
 
-export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear, clearDisabled, relLabelMode = "all", onRelLabelModeChange }: DockProps) {
+// The Add-object dock button, augmented with a hover-delay flyout for the
+// "Object labels" view setting and an always-visible corner badge showing the
+// active mode's glyph. Clicking the button activates the Add tool; the flyout
+// (revealed after ~0.5s hover) is a separate, view-only control.
+function AddObjectToolButton({
+  active,
+  onActivate,
+  objLabelMode,
+  onObjLabelModeChange,
+}: {
+  active: boolean;
+  onActivate: () => void;
+  objLabelMode: ObjLabelMode;
+  onObjLabelModeChange?: (mode: ObjLabelMode) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = () => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+  };
+  const handleEnter = () => {
+    clearTimer();
+    timer.current = setTimeout(() => setOpen(true), 500);
+  };
+  const handleLeave = () => {
+    clearTimer();
+    setOpen(false);
+  };
+  useEffect(() => clearTimer, []);
+
+  return (
+    <div className="relative group" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+      <button
+        onClick={onActivate}
+        aria-label="Add object (N) — or double-click canvas"
+        className={`
+          relative w-[38px] h-[38px] rounded-[9px] border-none flex items-center justify-center cursor-pointer transition-colors
+          ${active
+            ? "bg-[#e6f1fb] text-[#1e88e5]"
+            : "bg-transparent text-slate-500 hover:bg-[#f1f3f7] hover:text-slate-900"
+          }
+        `}
+      >
+        <AddIcon />
+        <span
+          data-testid="obj-label-badge"
+          aria-hidden
+          className="absolute -top-[3px] -right-[3px] min-w-[14px] h-[14px] px-[2px] rounded-full bg-slate-900 text-white text-[9px] leading-[14px] font-semibold text-center shadow-[0_1px_2px_rgba(15,23,42,0.4)]"
+        >
+          {OBJ_LABEL_GLYPH[objLabelMode]}
+        </span>
+      </button>
+
+      {!open && <DockTip label="Add object (N) — or double-click canvas" />}
+
+      {open && (
+        <div className="absolute left-[calc(100%+10px)] top-1/2 -translate-y-1/2 z-50">
+          {/* invisible bridge so the cursor can travel from button to menu without closing */}
+          <span className="absolute right-full top-0 h-full w-[12px]" />
+          <div className="w-[260px] rounded-xl border border-[#d8dee8] bg-white p-1.5 shadow-[0_8px_24px_rgba(15,23,42,0.14)]">
+            <div className="px-2 pt-1 pb-1.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+              Object labels
+            </div>
+            {OBJ_LABEL_OPTIONS.map(opt => {
+              const selected = opt.mode === objLabelMode;
+              return (
+                <button
+                  key={opt.mode}
+                  onClick={() => { onObjLabelModeChange?.(opt.mode); setOpen(false); }}
+                  className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${selected ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+                >
+                  <span className={`mt-[1px] w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${selected ? "text-[#1e88e5]" : "text-slate-400"}`}>
+                    {OBJ_LABEL_GLYPH[opt.mode]}
+                  </span>
+                  <span className="flex flex-col">
+                    <span className={`text-[13px] font-semibold ${selected ? "text-[#1e88e5]" : "text-slate-800"}`}>{opt.label}</span>
+                    <span className="text-[11px] leading-snug text-slate-500">{opt.helper}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear, clearDisabled, relLabelMode = "all", onRelLabelModeChange, objLabelMode = "all", onObjLabelModeChange }: DockProps) {
   // Keyboard shortcuts V/N/C
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -229,11 +335,11 @@ export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear
         active={activeTool === "select"}
         onClick={() => onToolChange("select")}
       />
-      <ToolButton
-        icon={<AddIcon />}
-        tip="Add object (N) — or double-click canvas"
+      <AddObjectToolButton
         active={activeTool === "add"}
-        onClick={() => onToolChange("add")}
+        onActivate={() => onToolChange("add")}
+        objLabelMode={objLabelMode}
+        onObjLabelModeChange={onObjLabelModeChange}
       />
       <ConnectToolButton
         active={activeTool === "connect"}

--- a/packages/web/src/components/canvas/MartNode.test.tsx
+++ b/packages/web/src/components/canvas/MartNode.test.tsx
@@ -12,12 +12,14 @@ const node = {
   ],
 };
 
-function renderNode(viewMode: "compact" | "erd") {
-  // MartNode is a React Flow node component; Handle needs the RF provider context.
+function renderNode(
+  viewMode: "compact" | "erd",
+  objLabelMode: "all" | "noSource" | "noFields" | "both" = "all",
+) {
   return render(
     <ReactFlowProvider>
       {/* @ts-expect-error minimal NodeProps for a render-only test */}
-      <MartNode id="n1" data={{ ...node, _viewMode: viewMode }} />
+      <MartNode id="n1" data={{ ...node, _viewMode: viewMode, _objLabelMode: objLabelMode }} />
     </ReactFlowProvider>,
   );
 }
@@ -35,5 +37,42 @@ describe("MartNode ERD rendering", () => {
     expect(screen.getByText("INT64")).toBeTruthy();
     expect(screen.getByText("email")).toBeTruthy();
     expect(screen.getByText("STRING")).toBeTruthy();
+  });
+});
+
+describe("MartNode object-labels", () => {
+  it("all: shows the source chip and field count", () => {
+    renderNode("compact", "all");
+    expect(screen.getByText("VIEW")).toBeTruthy();
+    expect(screen.getByText("2 fields")).toBeTruthy();
+  });
+
+  it("noSource: hides the source chip but keeps the field count", () => {
+    renderNode("compact", "noSource");
+    expect(screen.queryByText("VIEW")).toBeNull();
+    expect(screen.getByText("2 fields")).toBeTruthy();
+  });
+
+  it("noFields: hides the field count but keeps the source chip", () => {
+    renderNode("compact", "noFields");
+    expect(screen.getByText("VIEW")).toBeTruthy();
+    expect(screen.queryByText("2 fields")).toBeNull();
+  });
+
+  it("both: hides the source chip and the field count", () => {
+    renderNode("compact", "both");
+    expect(screen.queryByText("VIEW")).toBeNull();
+    expect(screen.queryByText("2 fields")).toBeNull();
+  });
+
+  it("defaults to showing everything when _objLabelMode is absent", () => {
+    render(
+      <ReactFlowProvider>
+        {/* @ts-expect-error minimal NodeProps for a render-only test */}
+        <MartNode id="n1" data={{ ...node, _viewMode: "compact" }} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("VIEW")).toBeTruthy();
+    expect(screen.getByText("2 fields")).toBeTruthy();
   });
 });

--- a/packages/web/src/components/canvas/MartNode.tsx
+++ b/packages/web/src/components/canvas/MartNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { KeyRound, ChevronDown, ChevronRight } from "lucide-react";
 import type { ModelNode, SchemaField } from "@mc/okf";
 import type { ViewMode } from "../../state/viewMode";
+import { showInputSource, showFieldCount, type ObjLabelMode } from "../../state/objLabels";
 import { DataMartIcon } from "../../lib/icons";
 import { ERD_COLLAPSED_ROWS } from "./layoutSize";
 
@@ -20,7 +21,7 @@ const STATUS_TIP: Record<string, string> = {
   error: "Error — check details",
 };
 
-export type MartNodeData = ModelNode & { _viewMode?: ViewMode; _keyFields?: string[] };
+export type MartNodeData = ModelNode & { _viewMode?: ViewMode; _keyFields?: string[]; _objLabelMode?: ObjLabelMode };
 
 function StatusDot({ status }: { status: string }) {
   const base = "absolute top-[10px] right-[10px] w-[9px] h-[9px] rounded-full z-10";
@@ -50,10 +51,10 @@ function NodePorts() {
   );
 }
 
-function MartHeader({ node, color }: { node: MartNodeData; color: string }) {
+function MartHeader({ node, color, showAccent }: { node: MartNodeData; color: string; showAccent: boolean }) {
   return (
     <div className="flex items-center gap-2 px-3 pt-[11px] pb-2">
-      <span className="w-1 self-stretch min-h-[18px] rounded-sm flex-shrink-0" style={{ background: color }} />
+      {showAccent && <span className="w-1 self-stretch min-h-[18px] rounded-sm flex-shrink-0" style={{ background: color }} />}
       <DataMartIcon size={15} className="text-slate-400 flex-shrink-0" />
       <span className="text-[13.5px] font-semibold flex-1 leading-tight pr-3 text-slate-900 line-clamp-2">
         {node.title}
@@ -128,6 +129,9 @@ function MartNodeInner({ data }: NodeProps) {
   const viewMode = node._viewMode ?? "compact";
   const color = SOURCE_COLOR[node.inputSource] ?? "#94a3b8";
   const isErd = viewMode === "erd";
+  const objLabelMode = node._objLabelMode ?? "all";
+  const withSource = showInputSource(objLabelMode);
+  const withFieldCount = !isErd && showFieldCount(objLabelMode);
   const fieldCount = node.schema?.length ?? 0;
   const fieldText = fieldCount > 0 ? `${fieldCount} field${fieldCount > 1 ? "s" : ""}` : "no fields";
 
@@ -137,18 +141,22 @@ function MartNodeInner({ data }: NodeProps) {
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif" }}
     >
       <StatusDot status={node.status} />
-      <MartHeader node={node} color={color} />
+      <MartHeader node={node} color={color} showAccent={withSource} />
 
-      {/* Meta row: type chip + (compact) field count */}
-      <div className="flex items-center gap-2 px-3 pb-[10px]">
-        <span
-          className="text-[10.5px] font-[650] uppercase tracking-[0.3px] px-[7px] py-[2px] rounded-full text-white"
-          style={{ background: color }}
-        >
-          {node.inputSource}
-        </span>
-        {!isErd && <span className="text-[11px] text-slate-500">{fieldText}</span>}
-      </div>
+      {/* Meta row: type chip + (compact) field count. Skipped entirely when both are hidden. */}
+      {(withSource || withFieldCount) && (
+        <div className="flex items-center gap-2 px-3 pb-[10px]">
+          {withSource && (
+            <span
+              className="text-[10.5px] font-[650] uppercase tracking-[0.3px] px-[7px] py-[2px] rounded-full text-white"
+              style={{ background: color }}
+            >
+              {node.inputSource}
+            </span>
+          )}
+          {withFieldCount && <span className="text-[11px] text-slate-500">{fieldText}</span>}
+        </div>
+      )}
 
       {isErd && <ErdBody node={node} />}
 

--- a/packages/web/src/state/objLabels.test.ts
+++ b/packages/web/src/state/objLabels.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  loadObjLabelMode,
+  persistObjLabelMode,
+  showInputSource,
+  showFieldCount,
+  type ObjLabelMode,
+} from "./objLabels";
+
+const MODES: ObjLabelMode[] = ["all", "noSource", "noFields", "both"];
+
+describe("objLabels persistence", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to 'all' when nothing is stored", () => {
+    expect(loadObjLabelMode()).toBe("all");
+  });
+
+  it("round-trips each valid mode", () => {
+    for (const m of MODES) {
+      persistObjLabelMode(m);
+      expect(loadObjLabelMode()).toBe(m);
+    }
+  });
+
+  it("falls back to 'all' for an unrecognised stored value", () => {
+    localStorage.setItem("mc.objLabels.v1", "bogus");
+    expect(loadObjLabelMode()).toBe("all");
+  });
+
+  it("tolerates a throwing localStorage on persist", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => persistObjLabelMode("both")).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+describe("showInputSource", () => {
+  it("shows the source chip+stripe only in all / noFields", () => {
+    expect(showInputSource("all")).toBe(true);
+    expect(showInputSource("noFields")).toBe(true);
+    expect(showInputSource("noSource")).toBe(false);
+    expect(showInputSource("both")).toBe(false);
+  });
+});
+
+describe("showFieldCount", () => {
+  it("shows the field count only in all / noSource", () => {
+    expect(showFieldCount("all")).toBe(true);
+    expect(showFieldCount("noSource")).toBe(true);
+    expect(showFieldCount("noFields")).toBe(false);
+    expect(showFieldCount("both")).toBe(false);
+  });
+});

--- a/packages/web/src/state/objLabels.ts
+++ b/packages/web/src/state/objLabels.ts
@@ -1,0 +1,33 @@
+// What each object node shows on the canvas. A per-browser view preference
+// (not model data) — persisted in localStorage, mirroring relLabels/viewMode.
+export type ObjLabelMode = "all" | "noSource" | "noFields" | "both";
+
+const KEY = "mc.objLabels.v1";
+const MODES: readonly ObjLabelMode[] = ["all", "noSource", "noFields", "both"];
+
+export function loadObjLabelMode(): ObjLabelMode {
+  try {
+    const v = localStorage.getItem(KEY);
+    return v !== null && MODES.includes(v as ObjLabelMode) ? (v as ObjLabelMode) : "all";
+  } catch {
+    return "all";
+  }
+}
+
+export function persistObjLabelMode(mode: ObjLabelMode): void {
+  try {
+    localStorage.setItem(KEY, mode);
+  } catch {
+    // best-effort; ignore quota / private-mode failures
+  }
+}
+
+// The source badge and the header accent stripe both encode inputSource colour,
+// so they show/hide together.
+export function showInputSource(mode: ObjLabelMode): boolean {
+  return mode === "all" || mode === "noFields";
+}
+
+export function showFieldCount(mode: ObjLabelMode): boolean {
+  return mode === "all" || mode === "noSource";
+}


### PR DESCRIPTION
## What

Adds an **Object labels** view preference — a single-select hover-flyout on the dock's **Add object** button that controls how much meta-info each object node shows on the canvas. Full mirror of the existing "Relationship labels" flyout on the Connect button.

Four modes (per-browser, default **Show everything**):

| Glyph | Mode | Effect on the node |
|-------|------|--------------------|
| `≡` | Show everything | Source badge + accent stripe + field count (current behavior) |
| `⬚` | Hide input source | Hides the `VIEW/TABLE/SQL/CONNECTOR` chip **and** the header accent stripe |
| `#` | Hide field count | Hides the `N fields` line |
| `⊘` | Hide both | Just the object title |

## Why

Dense canvases get noisy — users asked to strip the source-type icons and field counts to focus on structure. Mirrors the mechanics they already know from relationship labels (same flyout pattern, badge glyph, localStorage persistence).

## How

- `state/objLabels.ts` — mode type + `load`/`persist` (`mc.objLabels.v1`) + `showInputSource`/`showFieldCount` helpers (mirrors `relLabels.ts`).
- `Dock.tsx` — new `AddObjectToolButton` with the hover-flyout + corner badge.
- `MartNode.tsx` — chip, header accent stripe, and field-count line are now conditional. `showInputSource` gates chip **and** stripe together; field count stays compact-only. When both are hidden the meta-row div is dropped (no ghost padding).
- `Canvas.tsx` — owns `objLabelMode` state, injects `_objLabelMode` into node data, threads props to `Dock`.

`StatusDot`, `DataMartIcon`, ERD body, and ports are untouched. ERD mode never showed field counts, so the field-count modes only affect compact nodes.

## Testing

- New: `objLabels.test.ts` (helpers + persistence), object-labels cases in `Dock.test.tsx` and `MartNode.test.tsx`.
- Full suite: **387/387 passing**, `tsc --noEmit` clean, `pnpm build` clean.
- Manual browser verify: flyout, all 4 modes, ERD unaffected, survives reload.

## Follow-ups (non-blocking)

- `AddObjectToolButton` and `ConnectToolButton` are now ~100-line near-duplicates — candidate for a shared parameterized flyout component (spans pre-existing code).
- Both flyouts are hover/mouse-only (aria-hidden badge, no keyboard path) — inherited a11y gap worth addressing for both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)