### PR TITLE
chore: point user-facing GitHub links at OWOX/models

### DIFF
--- a/packages/web/src/components/SignInModal.tsx
+++ b/packages/web/src/components/SignInModal.tsx
@@ -110,7 +110,7 @@ export function SignInModal({ mode, connect, onConnected, onClose }: SignInModal
             never stored at rest, and used only for this session to read and update Data Marts in your
             project. The key stays in your browser and is cleared when you sign out. It's{" "}
             <a
-              href="https://github.com/OWOX/owox-model-canvas/blob/main/packages/server/src/auth/session.ts"
+              href="https://github.com/OWOX/models/blob/main/packages/server/src/auth/session.ts"
               target="_blank"
               rel="noreferrer"
               className="font-semibold text-[#1e88e5] hover:underline"

--- a/packages/web/src/okf/io.test.ts
+++ b/packages/web/src/okf/io.test.ts
@@ -23,7 +23,7 @@ describe("graphToBundleFiles", () => {
     const indexKey = Object.keys(files).find(k => k.endsWith("index.md"))!;
     expect(files[indexKey]).toContain("Generated with");
     expect(files[indexKey]).toContain("OWOX Data Marts");
-    expect(files[indexKey]).toContain("github.com/OWOX/owox-model-canvas");
+    expect(files[indexKey]).toContain("github.com/OWOX/models");
     const martKey = Object.keys(files).find(k => k.endsWith("orders.md"))!;
     expect(files[martKey]).not.toContain("Generated with"); // per-mart docs stay clean
   });

--- a/packages/web/src/okf/io.ts
+++ b/packages/web/src/okf/io.ts
@@ -7,7 +7,7 @@ const OKF_FOOTER =
   "\n\n---\n\n" +
   "_Generated with [OWOX Data Marts](https://www.owox.com/) · " +
   "[Model Canvas](https://model.owox.com/) · " +
-  "[open source](https://github.com/OWOX/owox-model-canvas)_\n";
+  "[open source](https://github.com/OWOX/models)_\n";
 
 export function graphToBundleFiles(g: ModelGraph, projectTitle: string): Record<string, string> {
   const files = serializeBundle(g, projectTitle).files;


### PR DESCRIPTION
Follow-up to the `owox-model-canvas → models` repo rename. Old links still work via GitHub's 301 redirect, but these reach users, so point them directly at the new name:

- **`io.ts`** — the OKF attribution footer embedded in **every exported bundle** `index.md`.
- **`io.test.ts`** — the assertion for that footer.
- **`SignInModal.tsx`** — the "open source — read the code" link.

Deliberately left unchanged: the deploy config and the root `package.json` name (internal, cosmetic).

387 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)