### PR TITLE
fix(gallery): verified-bundle niche pre-pick + abort expand fetch on unmount

### DIFF
--- a/packages/web/src/components/TemplateGallery.abort.test.tsx
+++ b/packages/web/src/components/TemplateGallery.abort.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { TemplateGallery } from "./TemplateGallery";
+import { fetchOkfBundleFromUrl } from "../okf/github";
+
+// Keep the per-bundle fetch in flight so we can observe the abort on unmount.
+vi.mock("../okf/github", () => ({
+  fetchOkfBundleFromUrl: vi.fn(() => new Promise(() => {})),
+}));
+
+const TOP_INDEX = `# OKF Bundles
+- [SaaS](./saas/index.md) — 10 concept(s)
+`;
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true, status: 200, text: () => Promise.resolve(TOP_INDEX),
+  }));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("VerifiedTemplateRow fetch cancellation", () => {
+  it("passes an AbortSignal to the bundle fetch and aborts it on unmount", async () => {
+    const { unmount } = render(<TemplateGallery onUse={vi.fn()} />);
+
+    // Expand the SaaS row → triggers the lazy bundle fetch.
+    fireEvent.click(await screen.findByText("SaaS"));
+    await waitFor(() => expect(fetchOkfBundleFromUrl).toHaveBeenCalled());
+
+    const opts = (fetchOkfBundleFromUrl as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][1] as { signal: AbortSignal };
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+    expect(opts.signal.aborted).toBe(false);
+
+    // Closing the dialog (unmount) must abort the still-in-flight request.
+    unmount();
+    expect(opts.signal.aborted).toBe(true);
+  });
+});

--- a/packages/web/src/components/TemplateGallery.test.tsx
+++ b/packages/web/src/components/TemplateGallery.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
-import { TemplateGallery } from "./TemplateGallery";
+import { TemplateGallery, verifiedTemplateName } from "./TemplateGallery";
 
 const TOP_INDEX = `# OKF Bundles
 - [E-Commerce](./e-commerce/index.md) — 22 concept(s)
@@ -37,5 +37,21 @@ describe("TemplateGallery", () => {
     expect(within(others).queryByText("Marketplace")).not.toBeInTheDocument();
     // A non-deduped built-in still appears.
     expect(within(others).getByText("Mobile / Gaming")).toBeInTheDocument();
+  });
+});
+
+describe("verifiedTemplateName", () => {
+  // Resolving to the built-in template name is what lets Canvas's TEMPLATE_NICHE
+  // lookup fire for verified bundles (fast-follow: niche pre-pick + model name).
+  it("maps a verified bundle folder to its matching built-in template name", () => {
+    expect(verifiedTemplateName("saas", "SaaS")).toBe("SaaS / Subscription");
+    expect(verifiedTemplateName("e-commerce", "E-Commerce")).toBe("E-commerce / Retail");
+    expect(verifiedTemplateName("marketing-leadgen", "Marketing Leadgen")).toBe("Marketing / Lead-gen");
+    expect(verifiedTemplateName("healthcare", "Healthcare")).toBe("Healthcare");
+    expect(verifiedTemplateName("marketplace", "Marketplace")).toBe("Marketplace");
+  });
+
+  it("falls back to the bundle title when no built-in template matches", () => {
+    expect(verifiedTemplateName("brand-new-vertical", "Brand New Vertical")).toBe("Brand New Vertical");
   });
 });

--- a/packages/web/src/components/TemplateGallery.tsx
+++ b/packages/web/src/components/TemplateGallery.tsx
@@ -33,6 +33,14 @@ const FOLDER_TO_TEMPLATE_ID: Record<string, string> = {
 function templateIdForFolder(folder: string): string {
   return FOLDER_TO_TEMPLATE_ID[folder] ?? folder.replace(/-/g, "_");
 }
+// Name to hand `onUse` for a verified bundle. When the bundle matches a built-in
+// template, use that template's name so Canvas's TEMPLATE_NICHE lookup fires
+// (Business-Goal pre-pick + niche-flavored model name); otherwise fall back to
+// the bundle's own title. The GitHub graph is used regardless — only the name.
+export function verifiedTemplateName(folder: string, fallbackTitle: string): string {
+  const id = templateIdForFolder(folder);
+  return [...INDUSTRY_TEMPLATES, ...DATASET_TEMPLATES].find(t => t.id === id)?.name ?? fallbackTitle;
+}
 // Until the verified list loads, fall back to the known set so Others never
 // flashes a duplicate for the common case.
 const DEFAULT_DEDUP = ["ecommerce", "saas", "finance", "medical", "marketing_ads"];
@@ -117,17 +125,22 @@ function VerifiedTemplateRow({
   const loadedRef = useRef(false);
   const inFlightRef = useRef<Promise<ModelGraph | null> | null>(null);
   const mountedRef = useRef(true);
+  const abortRef = useRef<AbortController | null>(null);
   const url = bundleGithubUrl(bundle.folder);
 
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  // On unmount, stop guarding state AND abort any in-flight bundle fetch so a
+  // dialog closed mid-load doesn't leave the network request running.
+  useEffect(() => () => { mountedRef.current = false; abortRef.current?.abort(); }, []);
 
   function load(): Promise<ModelGraph | null> {
     if (loadedRef.current && graph) return Promise.resolve(graph);
     if (inFlightRef.current) return inFlightRef.current;
 
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
     const promise = (async () => {
       try {
-        const files = await fetchOkfBundleFromUrl(url);
+        const files = await fetchOkfBundleFromUrl(url, { signal: ctrl.signal });
         const parsed = filesToGraph(files);
         // OKF carries no OWOX identity — mark nodes pending (mirrors ImportDialog).
         const g: ModelGraph = { ...parsed, nodes: parsed.nodes.map(n => ({ ...n, status: "pending" as const, owoxId: null })) };
@@ -138,6 +151,8 @@ function VerifiedTemplateRow({
         loadedRef.current = true;
         return g;
       } catch (e) {
+        // Aborted on unmount — not a real failure, and the component is gone.
+        if ((e as Error).name === "AbortError") return null;
         if (mountedRef.current) setError((e as Error).message ?? "Failed to load bundle.");
         return null;
       } finally {
@@ -157,7 +172,7 @@ function VerifiedTemplateRow({
   async function handleUse(e: React.MouseEvent) {
     e.stopPropagation();
     const g = graph ?? (await load());
-    if (g) onUse(g, bundle.title);
+    if (g) onUse(g, verifiedTemplateName(bundle.folder, bundle.title));
   }
 
   return (


### PR DESCRIPTION
Two non-blocking fast-follows from the PR #25 review.

### 1. Niche pre-pick + model name for verified bundles
Verified bundle titles ("SaaS", "E-Commerce", …) didn't match `TEMPLATE_NICHE` keys, so clicking **Use** on a gallery bundle skipped the Business-Goal niche pre-pick and produced a bare model name. Now the verified **Use** resolves the matching built-in template via the folder→id map and passes **its** name to `onUse`, so the existing `TEMPLATE_NICHE` + `templateModelName` logic fires. The GitHub bundle graph is used unchanged — only the name is resolved. Net-new bundles with no built-in match fall back to the bundle title.

### 2. Abort the expand fetch on unmount
`VerifiedTemplateRow` now threads an `AbortController` signal into `fetchOkfBundleFromUrl` and aborts it on unmount, so closing the dialog mid-load cancels the in-flight request instead of letting it run to completion. `AbortError` is no longer surfaced as a load failure.

### Tests
- `verifiedTemplateName` unit test (folder→built-in name mapping + fallback).
- Abort integration test (signal passed to the bundle fetch; aborted on unmount).
- Full web suite green (405), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)