### PR TITLE
Add the Finance model bundle

### DIFF
--- a/bundles/finance/index.md
+++ b/bundles/finance/index.md
@@ -1,6 +1,5 @@
 ---
 title: "Finance"
-authors: ["[Vlad Flaks](https://github.com/vladflaks)", "[Rus Obolonsky](https://github.com/Obolrus)"]
 description: |
   A consumer-lending business modeled end to end — from how customers are acquired and
   verified, through account funding and loan origination, to repayments, missed payments,
@@ -10,7 +9,7 @@ description: |
   the money and the risk across the entire loan book.
 tags: ["owox", "index"]
 type: "index"
-timestamp: 2026-07-24T16:29:01Z
+timestamp: 2026-07-24T16:44:30Z
 ---
 
 <!-- OWOX:GENERATED:START — regenerated on export, do not edit inside this block -->
@@ -25,6 +24,8 @@ timestamp: 2026-07-24T16:29:01Z
 | [Product](./product.md) | 5 |
 | [Repayments](./repayments.md) | 9 |
 | [Transactions](./transactions.md) | 11 |
+
+**Authors:** [Vlad Flaks](https://github.com/vladflaks), [Rus Obolonsky](https://github.com/Obolrus)
 
 # Example Questions
 

--- a/bundles/index.md
+++ b/bundles/index.md
@@ -3,12 +3,12 @@ title: "OKF Bundles"
 description: "OKF bundles generated from OWOX Data Marts."
 tags: ["owox", "index"]
 type: "index"
-timestamp: 2026-07-24T16:29:01Z
+timestamp: 2026-07-24T16:44:30Z
 ---
 
 # OKF Bundles
 
-Generated 2026-07-24T16:29:01Z.
+Generated 2026-07-24T16:44:30Z.
 
 - [E-Commerce](./e-commerce/index.md) — 22 concept(s)
 - [Finance](./finance/index.md) — 8 concept(s)


### PR DESCRIPTION
Adds the **Finance** niche model to the gallery as `bundles/finance/` (8 data marts).

Generated with `tools/odm-to-okf-export/export.py` from the live, PUBLISHED data marts of the model's OWOX project. The bundle was linted with the same OKF parser used to author it, and the export was verified to leave every other bundle in `bundles/` untouched.

