### PR TITLE
Update the Finance model bundle

### DIFF
--- a/bundles/finance/index.md
+++ b/bundles/finance/index.md
@@ -9,10 +9,12 @@ description: |
   the money and the risk across the entire loan book.
 tags: ["owox", "index"]
 type: "index"
-timestamp: 2026-07-24T16:44:30Z
+timestamp: 2026-07-24T16:49:04Z
 ---
 
 <!-- OWOX:GENERATED:START — regenerated on export, do not edit inside this block -->
+
+**Authors:** [Vlad Flaks](https://github.com/vladflaks), [Rus Obolonsky](https://github.com/Obolrus)
 
 | Data Mart | Fields |
 |-----------|--------|
@@ -24,8 +26,6 @@ timestamp: 2026-07-24T16:44:30Z
 | [Product](./product.md) | 5 |
 | [Repayments](./repayments.md) | 9 |
 | [Transactions](./transactions.md) | 11 |
-
-**Authors:** [Vlad Flaks](https://github.com/vladflaks), [Rus Obolonsky](https://github.com/Obolrus)
 
 # Example Questions
 

--- a/bundles/index.md
+++ b/bundles/index.md
@@ -3,12 +3,12 @@ title: "OKF Bundles"
 description: "OKF bundles generated from OWOX Data Marts."
 tags: ["owox", "index"]
 type: "index"
-timestamp: 2026-07-24T16:44:30Z
+timestamp: 2026-07-24T16:49:04Z
 ---
 
 # OKF Bundles
 
-Generated 2026-07-24T16:44:30Z.
+Generated 2026-07-24T16:49:04Z.
 
 - [E-Commerce](./e-commerce/index.md) — 22 concept(s)
 - [Finance](./finance/index.md) — 8 concept(s)


### PR DESCRIPTION
Updates the **Finance** niche model bundle at `bundles/finance/` (8 data marts).

Generated with `tools/odm-to-okf-export/export.py` from the live, PUBLISHED data marts of the model's OWOX project. The bundle was linted with the same OKF parser used to author it, and the export was verified to leave every other bundle in `bundles/` untouched.

