### PR TITLE
feat(canvas): multi-select object labels, status dot hideable

### DIFF
--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -26,7 +26,7 @@ import { createModelStore } from "../../state/model";
 import { loadPersistedGraph, persistGraph } from "../../state/persist";
 import { loadViewMode, persistViewMode, type ViewMode } from "../../state/viewMode";
 import { loadRelLabelMode, persistRelLabelMode, type RelLabelMode } from "../../state/relLabels";
-import { loadObjLabelMode, persistObjLabelMode, type ObjLabelMode } from "../../state/objLabels";
+import { loadObjHidden, persistObjHidden, type ObjHidden } from "../../state/objLabels";
 import { loadModelName, persistModelName, DEFAULT_MODEL_NAME, templateModelName } from "../../state/modelName";
 import type { ModelNode, ModelEdge, ModelGraph } from "@mc/okf";
 
@@ -132,12 +132,12 @@ const TEMPLATE_NICHE: Record<string, string> = {
 };
 
 // ── helpers to convert between model and RF types ───────────────────────────
-function toRFNode(n: ModelNode, viewMode: ViewMode, objLabelMode: ObjLabelMode, keyFields?: string[]): Node {
+function toRFNode(n: ModelNode, viewMode: ViewMode, objHidden: ObjHidden, keyFields?: string[]): Node {
   return {
     id: n.key,
     type: "mart",
     position: n.position,
-    data: { ...n, _viewMode: viewMode, _keyFields: keyFields, _objLabelMode: objLabelMode } as unknown as Record<string, unknown>,
+    data: { ...n, _viewMode: viewMode, _keyFields: keyFields, _objHidden: objHidden } as unknown as Record<string, unknown>,
   };
 }
 
@@ -226,10 +226,10 @@ function CanvasInner() {
     setRelLabelMode(mode);
     persistRelLabelMode(mode);
   }, []);
-  const [objLabelMode, setObjLabelMode] = useState<ObjLabelMode>(loadObjLabelMode());
-  const handleObjLabelModeChange = useCallback((mode: ObjLabelMode) => {
-    setObjLabelMode(mode);
-    persistObjLabelMode(mode);
+  const [objHidden, setObjHidden] = useState<ObjHidden>(loadObjHidden());
+  const handleObjHiddenChange = useCallback((hidden: ObjHidden) => {
+    setObjHidden(hidden);
+    persistObjHidden(hidden);
   }, []);
   const [showImport, setShowImport] = useState(false);
   // Deeplink: open Import pre-filled for a `?okf=` bundle URL, once, on mount.
@@ -341,8 +341,8 @@ function CanvasInner() {
 
   useEffect(() => {
     const kf = keyFieldsByNode(graph.edges);
-    setRfNodes(graph.nodes.map(n => toRFNode(n, viewMode, objLabelMode, [...(kf.get(n.key) ?? [])])));
-  }, [graph.nodes, graph.edges, viewMode, objLabelMode, setRfNodes]);
+    setRfNodes(graph.nodes.map(n => toRFNode(n, viewMode, objHidden, [...(kf.get(n.key) ?? [])])));
+  }, [graph.nodes, graph.edges, viewMode, objHidden, setRfNodes]);
   useEffect(() => { setRfEdges(buildRfEdges(graph.edges, graph.nodes, viewMode, relLabelMode)); }, [graph.edges, graph.nodes, viewMode, relLabelMode, setRfEdges]);
 
   // Mark only the selected relationship as reconnectable so dragging an endpoint
@@ -942,7 +942,7 @@ function CanvasInner() {
         >
           {/* Tool dock — anchored to the canvas (not the outer row) so it sits
               just inside the canvas edge and slides over as the rail opens. */}
-          <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} onClear={() => setShowClear(true)} clearDisabled={graph.nodes.length === 0} relLabelMode={relLabelMode} onRelLabelModeChange={handleRelLabelModeChange} objLabelMode={objLabelMode} onObjLabelModeChange={handleObjLabelModeChange} />
+          <Dock activeTool={tool} onToolChange={handleToolChange} viewMode={viewMode} onToggleView={handleToggleView} onClear={() => setShowClear(true)} clearDisabled={graph.nodes.length === 0} relLabelMode={relLabelMode} onRelLabelModeChange={handleRelLabelModeChange} objHidden={objHidden} onObjHiddenChange={handleObjHiddenChange} />
           <ReactFlow
             nodes={rfNodes}
             edges={rfEdges}

--- a/packages/web/src/components/canvas/Dock.test.tsx
+++ b/packages/web/src/components/canvas/Dock.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { Dock } from "./Dock";
+import { NOTHING_HIDDEN, ALL_HIDDEN } from "../../state/objLabels";
 
 const base = {
   activeTool: "select" as const,
@@ -52,35 +53,83 @@ describe("Dock object-labels flyout", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it("opens the flyout 0.5s after hovering Add and lists all four modes", () => {
-    render(<Dock {...base} objLabelMode="all" onObjLabelModeChange={() => {}} />);
-    const add = screen.getByRole("button", { name: /add object/i });
-    fireEvent.mouseEnter(add.parentElement!);
-    expect(screen.queryByText("Show everything")).toBeNull(); // delay pending
-    act(() => { vi.advanceTimersByTime(500); });
-    expect(screen.getByText("Show everything")).toBeTruthy();
-    expect(screen.getByText("Hide input source")).toBeTruthy();
-    expect(screen.getByText("Hide field count")).toBeTruthy();
-    expect(screen.getByText("Hide both")).toBeTruthy();
-  });
-
-  it("calls onObjLabelModeChange with the picked mode", () => {
-    const onPick = vi.fn();
-    render(<Dock {...base} objLabelMode="all" onObjLabelModeChange={onPick} />);
+  const openFlyout = () => {
     fireEvent.mouseEnter(screen.getByRole("button", { name: /add object/i }).parentElement!);
     act(() => { vi.advanceTimersByTime(500); });
-    fireEvent.click(screen.getByText("Hide both"));
-    expect(onPick).toHaveBeenCalledWith("both");
+  };
+
+  it("opens the flyout 0.5s after hovering Add and lists every hideable part", () => {
+    render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
+    expect(screen.queryByText("Show everything")).toBeNull(); // delay pending
+    openFlyout();
+    expect(screen.getByText("Show everything")).toBeTruthy();
+    expect(screen.getByText("Hide all")).toBeTruthy();
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes.map(b => b.getAttribute("aria-checked"))).toEqual(["false", "false", "false"]);
+    expect(screen.getByText("Input source")).toBeTruthy();
+    expect(screen.getByText("Field count")).toBeTruthy();
+    expect(screen.getByText("Status dot")).toBeTruthy();
   });
 
-  it("shows the glyph of the active mode as a badge", () => {
-    render(<Dock {...base} objLabelMode="noFields" onObjLabelModeChange={() => {}} />);
-    expect(screen.getByTestId("obj-label-badge").textContent).toBe("#");
+  it("toggles one part at a time, leaving the others alone", () => {
+    const onChange = vi.fn();
+    render(<Dock {...base} objHidden={{ source: true, fields: false, status: false }} onObjHiddenChange={onChange} />);
+    openFlyout();
+    fireEvent.click(screen.getByRole("checkbox", { name: /Status dot/ }));
+    expect(onChange).toHaveBeenCalledWith({ source: true, fields: false, status: true });
+  });
+
+  it("unchecks an already-hidden part", () => {
+    const onChange = vi.fn();
+    render(<Dock {...base} objHidden={{ source: true, fields: false, status: true }} onObjHiddenChange={onChange} />);
+    openFlyout();
+    expect(screen.getByRole("checkbox", { name: /Status dot/ }).getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(screen.getByRole("checkbox", { name: /Status dot/ }));
+    expect(onChange).toHaveBeenCalledWith({ source: true, fields: false, status: false });
+  });
+
+  it("keeps the flyout open across toggles so several parts can be picked", () => {
+    render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
+    openFlyout();
+    fireEvent.click(screen.getByRole("checkbox", { name: /Field count/ }));
+    expect(screen.getByText("Show everything")).toBeTruthy();
+    fireEvent.click(screen.getByRole("checkbox", { name: /Status dot/ }));
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+  });
+
+  it("resets to nothing hidden via Show everything, and hides everything via Hide all", () => {
+    const onChange = vi.fn();
+    render(<Dock {...base} objHidden={ALL_HIDDEN} onObjHiddenChange={onChange} />);
+    openFlyout();
+    expect(screen.getByTestId("obj-label-hide-all").getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(screen.getByTestId("obj-label-reset"));
+    expect(onChange).toHaveBeenCalledWith(NOTHING_HIDDEN);
+    fireEvent.click(screen.getByTestId("obj-label-hide-all"));
+    expect(onChange).toHaveBeenLastCalledWith(ALL_HIDDEN);
+  });
+
+  it("marks Show everything as the active row when nothing is hidden", () => {
+    render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
+    openFlyout();
+    expect(screen.getByTestId("obj-label-reset").getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByTestId("obj-label-hide-all").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("summarises what's hidden in the corner badge", () => {
+    const badge = () => screen.getByTestId("obj-label-badge").textContent;
+    const { rerender } = render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
+    expect(badge()).toBe("≡");
+    rerender(<Dock {...base} objHidden={{ source: false, fields: true, status: false }} onObjHiddenChange={() => {}} />);
+    expect(badge()).toBe("#");
+    rerender(<Dock {...base} objHidden={{ source: true, fields: false, status: true }} onObjHiddenChange={() => {}} />);
+    expect(badge()).toBe("2");
+    rerender(<Dock {...base} objHidden={ALL_HIDDEN} onObjHiddenChange={() => {}} />);
+    expect(badge()).toBe("⊘");
   });
 
   it("still activates the Add tool when the button itself is clicked", () => {
     const onToolChange = vi.fn();
-    render(<Dock {...base} onToolChange={onToolChange} objLabelMode="all" onObjLabelModeChange={() => {}} />);
+    render(<Dock {...base} onToolChange={onToolChange} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /add object/i }));
     expect(onToolChange).toHaveBeenCalledWith("add");
   });

--- a/packages/web/src/components/canvas/Dock.tsx
+++ b/packages/web/src/components/canvas/Dock.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useRef, useState } from "react";
+import { Check } from "lucide-react";
 import type { ViewMode } from "../../state/viewMode";
 import type { RelLabelMode } from "../../state/relLabels";
-import type { ObjLabelMode } from "../../state/objLabels";
+import {
+  OBJ_LABEL_PARTS,
+  NOTHING_HIDDEN,
+  ALL_HIDDEN,
+  hiddenCount,
+  isNothingHidden,
+  isAllHidden,
+  togglePart,
+  type ObjHidden,
+  type ObjLabelPart,
+} from "../../state/objLabels";
 
 export type Tool = "select" | "add" | "connect" | "layout";
 
@@ -19,19 +30,22 @@ const REL_LABEL_OPTIONS: { mode: RelLabelMode; label: string; helper: string }[]
   { mode: "hidden", label: "Hide all labels", helper: "Just the connector lines — no keys, no cardinality" },
 ];
 
-const OBJ_LABEL_GLYPH: Record<ObjLabelMode, string> = {
-  all: "≡",
-  noSource: "⬚",
-  noFields: "#",
-  both: "⊘",
+const OBJ_PART_META: Record<ObjLabelPart, { glyph: string; label: string; helper: string }> = {
+  source: { glyph: "⬚", label: "Input source", helper: "The source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent stripe" },
+  fields: { glyph: "#", label: "Field count", helper: "The field-count line under each object" },
+  status: { glyph: "•", label: "Status dot", helper: "The push-status dot in the object's top-right corner" },
 };
 
-const OBJ_LABEL_OPTIONS: { mode: ObjLabelMode; label: string; helper: string }[] = [
-  { mode: "all", label: "Show everything", helper: "Input source and field count on every object" },
-  { mode: "noSource", label: "Hide input source", helper: "Hide the source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent" },
-  { mode: "noFields", label: "Hide field count", helper: "Hide the field-count line under each object" },
-  { mode: "both", label: "Hide both", helper: "Just the object title — no source badge, no field count" },
-];
+// Corner badge on the Add button: the default glyph when nothing is hidden, the
+// hidden part's own glyph when exactly one is, "⊘" when everything is, and the
+// count in between — so the badge always says how much is suppressed.
+function objBadgeGlyph(hidden: ObjHidden): string {
+  const n = hiddenCount(hidden);
+  if (n === 0) return "≡";
+  if (n === OBJ_LABEL_PARTS.length) return "⊘";
+  if (n === 1) return OBJ_PART_META[OBJ_LABEL_PARTS.find(p => hidden[p])!].glyph;
+  return String(n);
+}
 
 interface DockProps {
   activeTool: Tool;
@@ -42,8 +56,8 @@ interface DockProps {
   clearDisabled?: boolean;
   relLabelMode?: RelLabelMode;
   onRelLabelModeChange?: (mode: RelLabelMode) => void;
-  objLabelMode?: ObjLabelMode;
-  onObjLabelModeChange?: (mode: ObjLabelMode) => void;
+  objHidden?: ObjHidden;
+  onObjHiddenChange?: (hidden: ObjHidden) => void;
 }
 
 const SelectIcon = () => (
@@ -221,22 +235,26 @@ function ConnectToolButton({
 }
 
 // The Add-object dock button, augmented with a hover-delay flyout for the
-// "Object labels" view setting and an always-visible corner badge showing the
-// active mode's glyph. Clicking the button activates the Add tool; the flyout
-// (revealed after ~0.5s hover) is a separate, view-only control.
+// "Object labels" view setting and an always-visible corner badge summarising
+// what's hidden. Clicking the button activates the Add tool; the flyout
+// (revealed after ~0.5s hover) is a separate, view-only control. The flyout is
+// multi-select: each part toggles on its own and the menu stays open, with
+// "Show everything" as the always-visible way back to the default.
 function AddObjectToolButton({
   active,
   onActivate,
-  objLabelMode,
-  onObjLabelModeChange,
+  objHidden,
+  onObjHiddenChange,
 }: {
   active: boolean;
   onActivate: () => void;
-  objLabelMode: ObjLabelMode;
-  onObjLabelModeChange?: (mode: ObjLabelMode) => void;
+  objHidden: ObjHidden;
+  onObjHiddenChange?: (hidden: ObjHidden) => void;
 }) {
   const [open, setOpen] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nothingHidden = isNothingHidden(objHidden);
+  const allHidden = isAllHidden(objHidden);
 
   const clearTimer = () => {
     if (timer.current) { clearTimeout(timer.current); timer.current = null; }
@@ -270,7 +288,7 @@ function AddObjectToolButton({
           aria-hidden
           className="absolute -top-[3px] -right-[3px] min-w-[14px] h-[14px] px-[2px] rounded-full bg-slate-900 text-white text-[9px] leading-[14px] font-semibold text-center shadow-[0_1px_2px_rgba(15,23,42,0.4)]"
         >
-          {OBJ_LABEL_GLYPH[objLabelMode]}
+          {objBadgeGlyph(objHidden)}
         </span>
       </button>
 
@@ -280,28 +298,63 @@ function AddObjectToolButton({
         <div className="absolute left-[calc(100%+10px)] top-1/2 -translate-y-1/2 z-50">
           {/* invisible bridge so the cursor can travel from button to menu without closing */}
           <span className="absolute right-full top-0 h-full w-[12px]" />
-          <div className="w-[260px] rounded-xl border border-[#d8dee8] bg-white p-1.5 shadow-[0_8px_24px_rgba(15,23,42,0.14)]">
+          <div className="w-[264px] rounded-xl border border-[#d8dee8] bg-white p-1.5 shadow-[0_8px_24px_rgba(15,23,42,0.14)]">
             <div className="px-2 pt-1 pb-1.5 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
               Object labels
             </div>
-            {OBJ_LABEL_OPTIONS.map(opt => {
-              const selected = opt.mode === objLabelMode;
+
+            {/* Reset row: shows the current state when nothing is hidden and is
+                the one-click way back to it otherwise. */}
+            <button
+              data-testid="obj-label-reset"
+              aria-pressed={nothingHidden}
+              onClick={() => onObjHiddenChange?.(NOTHING_HIDDEN)}
+              className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${nothingHidden ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+            >
+              <span className={`w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-400"}`}>≡</span>
+              <span className={`text-[13px] font-semibold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Show everything</span>
+            </button>
+
+            <div className="px-2 pt-2 pb-1 text-[10.5px] font-semibold uppercase tracking-wide text-slate-400">
+              Hide — pick any
+            </div>
+
+            {OBJ_LABEL_PARTS.map(part => {
+              const meta = OBJ_PART_META[part];
+              const checked = objHidden[part];
               return (
                 <button
-                  key={opt.mode}
-                  onClick={() => { onObjLabelModeChange?.(opt.mode); setOpen(false); }}
-                  className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${selected ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+                  key={part}
+                  role="checkbox"
+                  aria-checked={checked}
+                  onClick={() => onObjHiddenChange?.(togglePart(objHidden, part))}
+                  className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${checked ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
                 >
-                  <span className={`mt-[1px] w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${selected ? "text-[#1e88e5]" : "text-slate-400"}`}>
-                    {OBJ_LABEL_GLYPH[opt.mode]}
+                  <span className={`mt-[2px] flex h-[14px] w-[14px] flex-shrink-0 items-center justify-center rounded-[4px] border transition-colors ${checked ? "border-[#1e88e5] bg-[#1e88e5] text-white" : "border-slate-300 bg-white text-transparent"}`}>
+                    <Check size={10} strokeWidth={3.5} />
                   </span>
                   <span className="flex flex-col">
-                    <span className={`text-[13px] font-semibold ${selected ? "text-[#1e88e5]" : "text-slate-800"}`}>{opt.label}</span>
-                    <span className="text-[11px] leading-snug text-slate-500">{opt.helper}</span>
+                    <span className={`text-[13px] font-semibold ${checked ? "text-[#1e88e5]" : "text-slate-800"}`}>
+                      <span className="mr-1 font-bold text-slate-400">{meta.glyph}</span>
+                      {meta.label}
+                    </span>
+                    <span className="text-[11px] leading-snug text-slate-500">{meta.helper}</span>
                   </span>
                 </button>
               );
             })}
+
+            <div className="mt-1 border-t border-[#eef1f5] pt-1">
+              <button
+                data-testid="obj-label-hide-all"
+                aria-pressed={allHidden}
+                onClick={() => onObjHiddenChange?.(ALL_HIDDEN)}
+                className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${allHidden ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+              >
+                <span className={`w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${allHidden ? "text-[#1e88e5]" : "text-slate-400"}`}>⊘</span>
+                <span className={`text-[13px] font-semibold ${allHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Hide all</span>
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -309,7 +362,7 @@ function AddObjectToolButton({
   );
 }
 
-export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear, clearDisabled, relLabelMode = "all", onRelLabelModeChange, objLabelMode = "all", onObjLabelModeChange }: DockProps) {
+export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear, clearDisabled, relLabelMode = "all", onRelLabelModeChange, objHidden = NOTHING_HIDDEN, onObjHiddenChange }: DockProps) {
   // Keyboard shortcuts V/N/C
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -338,8 +391,8 @@ export function Dock({ activeTool, onToolChange, viewMode, onToggleView, onClear
       <AddObjectToolButton
         active={activeTool === "add"}
         onActivate={() => onToolChange("add")}
-        objLabelMode={objLabelMode}
-        onObjLabelModeChange={onObjLabelModeChange}
+        objHidden={objHidden}
+        onObjHiddenChange={onObjHiddenChange}
       />
       <ConnectToolButton
         active={activeTool === "connect"}

--- a/packages/web/src/components/canvas/MartNode.test.tsx
+++ b/packages/web/src/components/canvas/MartNode.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { MartNode } from "./MartNode";
+import { NOTHING_HIDDEN, ALL_HIDDEN, type ObjHidden } from "../../state/objLabels";
 
 const node = {
   key: "n1", title: "Users", inputSource: "VIEW", status: "created", owoxId: "x",
@@ -12,14 +13,11 @@ const node = {
   ],
 };
 
-function renderNode(
-  viewMode: "compact" | "erd",
-  objLabelMode: "all" | "noSource" | "noFields" | "both" = "all",
-) {
+function renderNode(viewMode: "compact" | "erd", hidden: Partial<ObjHidden> = {}) {
   return render(
     <ReactFlowProvider>
       {/* @ts-expect-error minimal NodeProps for a render-only test */}
-      <MartNode id="n1" data={{ ...node, _viewMode: viewMode, _objLabelMode: objLabelMode }} />
+      <MartNode id="n1" data={{ ...node, _viewMode: viewMode, _objHidden: { ...NOTHING_HIDDEN, ...hidden } }} />
     </ReactFlowProvider>,
   );
 }
@@ -41,31 +39,50 @@ describe("MartNode ERD rendering", () => {
 });
 
 describe("MartNode object-labels", () => {
-  it("all: shows the source chip and field count", () => {
-    renderNode("compact", "all");
+  it("nothing hidden: shows the source chip, field count and status dot", () => {
+    renderNode("compact");
+    expect(screen.getByText("VIEW")).toBeTruthy();
+    expect(screen.getByText("2 fields")).toBeTruthy();
+    expect(screen.getByTestId("status-dot")).toBeTruthy();
+  });
+
+  it("hides the source chip on its own", () => {
+    renderNode("compact", { source: true });
+    expect(screen.queryByText("VIEW")).toBeNull();
+    expect(screen.getByText("2 fields")).toBeTruthy();
+    expect(screen.getByTestId("status-dot")).toBeTruthy();
+  });
+
+  it("hides the field count on its own", () => {
+    renderNode("compact", { fields: true });
+    expect(screen.getByText("VIEW")).toBeTruthy();
+    expect(screen.queryByText("2 fields")).toBeNull();
+    expect(screen.getByTestId("status-dot")).toBeTruthy();
+  });
+
+  it("hides the status dot on its own — the combination the enum couldn't express", () => {
+    renderNode("compact", { status: true });
+    expect(screen.queryByTestId("status-dot")).toBeNull();
     expect(screen.getByText("VIEW")).toBeTruthy();
     expect(screen.getByText("2 fields")).toBeTruthy();
   });
 
-  it("noSource: hides the source chip but keeps the field count", () => {
-    renderNode("compact", "noSource");
+  it("hides the source chip and the status dot while keeping the field count", () => {
+    renderNode("compact", { source: true, status: true });
     expect(screen.queryByText("VIEW")).toBeNull();
+    expect(screen.queryByTestId("status-dot")).toBeNull();
     expect(screen.getByText("2 fields")).toBeTruthy();
   });
 
-  it("noFields: hides the field count but keeps the source chip", () => {
-    renderNode("compact", "noFields");
-    expect(screen.getByText("VIEW")).toBeTruthy();
-    expect(screen.queryByText("2 fields")).toBeNull();
-  });
-
-  it("both: hides the source chip and the field count", () => {
-    renderNode("compact", "both");
+  it("all hidden: leaves just the title", () => {
+    renderNode("compact", ALL_HIDDEN);
     expect(screen.queryByText("VIEW")).toBeNull();
     expect(screen.queryByText("2 fields")).toBeNull();
+    expect(screen.queryByTestId("status-dot")).toBeNull();
+    expect(screen.getByText("Users")).toBeTruthy();
   });
 
-  it("defaults to showing everything when _objLabelMode is absent", () => {
+  it("defaults to showing everything when _objHidden is absent", () => {
     render(
       <ReactFlowProvider>
         {/* @ts-expect-error minimal NodeProps for a render-only test */}
@@ -74,5 +91,6 @@ describe("MartNode object-labels", () => {
     );
     expect(screen.getByText("VIEW")).toBeTruthy();
     expect(screen.getByText("2 fields")).toBeTruthy();
+    expect(screen.getByTestId("status-dot")).toBeTruthy();
   });
 });

--- a/packages/web/src/components/canvas/MartNode.tsx
+++ b/packages/web/src/components/canvas/MartNode.tsx
@@ -3,7 +3,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { KeyRound, ChevronDown, ChevronRight } from "lucide-react";
 import type { ModelNode, SchemaField } from "@mc/okf";
 import type { ViewMode } from "../../state/viewMode";
-import { showInputSource, showFieldCount, type ObjLabelMode } from "../../state/objLabels";
+import { NOTHING_HIDDEN, type ObjHidden } from "../../state/objLabels";
 import { DataMartIcon } from "../../lib/icons";
 import { ERD_COLLAPSED_ROWS } from "./layoutSize";
 
@@ -21,7 +21,7 @@ const STATUS_TIP: Record<string, string> = {
   error: "Error — check details",
 };
 
-export type MartNodeData = ModelNode & { _viewMode?: ViewMode; _keyFields?: string[]; _objLabelMode?: ObjLabelMode };
+export type MartNodeData = ModelNode & { _viewMode?: ViewMode; _keyFields?: string[]; _objHidden?: ObjHidden };
 
 function StatusDot({ status }: { status: string }) {
   const base = "absolute top-[10px] right-[10px] w-[9px] h-[9px] rounded-full z-10";
@@ -32,7 +32,11 @@ function StatusDot({ status }: { status: string }) {
     error: "bg-[#ef4444]",
   };
   return (
-    <span className={`${base} ${colors[status] ?? "bg-slate-300"}`} title={STATUS_TIP[status] ?? status} />
+    <span
+      data-testid="status-dot"
+      className={`${base} ${colors[status] ?? "bg-slate-300"}`}
+      title={STATUS_TIP[status] ?? status}
+    />
   );
 }
 
@@ -129,9 +133,12 @@ function MartNodeInner({ data }: NodeProps) {
   const viewMode = node._viewMode ?? "compact";
   const color = SOURCE_COLOR[node.inputSource] ?? "#94a3b8";
   const isErd = viewMode === "erd";
-  const objLabelMode = node._objLabelMode ?? "all";
-  const withSource = showInputSource(objLabelMode);
-  const withFieldCount = !isErd && showFieldCount(objLabelMode);
+  const hidden = node._objHidden ?? NOTHING_HIDDEN;
+  // The source badge and the header accent stripe both encode inputSource
+  // colour, so they show and hide together.
+  const withSource = !hidden.source;
+  const withFieldCount = !isErd && !hidden.fields;
+  const withStatus = !hidden.status;
   const fieldCount = node.schema?.length ?? 0;
   const fieldText = fieldCount > 0 ? `${fieldCount} field${fieldCount > 1 ? "s" : ""}` : "no fields";
 
@@ -140,7 +147,7 @@ function MartNodeInner({ data }: NodeProps) {
       className={`relative bg-white border-[1.5px] border-[#d8dee8] rounded-xl shadow-[0_2px_8px_rgba(15,23,42,0.05)] cursor-grab hover:border-[#c2cad8] select-none ${isErd ? "w-[250px]" : "w-[200px]"}`}
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif" }}
     >
-      <StatusDot status={node.status} />
+      {withStatus && <StatusDot status={node.status} />}
       <MartHeader node={node} color={color} showAccent={withSource} />
 
       {/* Meta row: type chip + (compact) field count. Skipped entirely when both are hidden. */}

--- a/packages/web/src/state/objLabels.test.ts
+++ b/packages/web/src/state/objLabels.test.ts
@@ -1,56 +1,99 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
-  loadObjLabelMode,
-  persistObjLabelMode,
-  showInputSource,
-  showFieldCount,
-  type ObjLabelMode,
+  loadObjHidden,
+  persistObjHidden,
+  togglePart,
+  hiddenCount,
+  isNothingHidden,
+  isAllHidden,
+  NOTHING_HIDDEN,
+  ALL_HIDDEN,
+  OBJ_LABEL_PARTS,
 } from "./objLabels";
 
-const MODES: ObjLabelMode[] = ["all", "noSource", "noFields", "both"];
+const KEY = "mc.objLabels.v2";
+const LEGACY_KEY = "mc.objLabels.v1";
 
 describe("objLabels persistence", () => {
   beforeEach(() => localStorage.clear());
 
-  it("defaults to 'all' when nothing is stored", () => {
-    expect(loadObjLabelMode()).toBe("all");
+  it("defaults to hiding nothing when storage is empty", () => {
+    expect(loadObjHidden()).toEqual(NOTHING_HIDDEN);
   });
 
-  it("round-trips each valid mode", () => {
-    for (const m of MODES) {
-      persistObjLabelMode(m);
-      expect(loadObjLabelMode()).toBe(m);
+  it("round-trips an arbitrary combination", () => {
+    const hidden = { source: false, fields: true, status: true };
+    persistObjHidden(hidden);
+    expect(loadObjHidden()).toEqual(hidden);
+  });
+
+  it("round-trips the empty set as an explicit stored value", () => {
+    persistObjHidden(ALL_HIDDEN);
+    persistObjHidden(NOTHING_HIDDEN);
+    expect(localStorage.getItem(KEY)).toBe("");
+    expect(loadObjHidden()).toEqual(NOTHING_HIDDEN);
+  });
+
+  it("ignores unknown parts in a stored value", () => {
+    localStorage.setItem(KEY, "source,bogus");
+    expect(loadObjHidden()).toEqual({ source: true, fields: false, status: false });
+  });
+
+  it("migrates each legacy v1 mode", () => {
+    const cases: [string, ReturnType<typeof loadObjHidden>][] = [
+      ["all", NOTHING_HIDDEN],
+      ["noSource", { source: true, fields: false, status: false }],
+      ["noFields", { source: false, fields: true, status: false }],
+      ["noStatus", { source: false, fields: false, status: true }],
+      ["both", { source: true, fields: true, status: false }],
+      ["none", ALL_HIDDEN],
+    ];
+    for (const [legacy, expected] of cases) {
+      localStorage.clear();
+      localStorage.setItem(LEGACY_KEY, legacy);
+      expect(loadObjHidden()).toEqual(expected);
     }
   });
 
-  it("falls back to 'all' for an unrecognised stored value", () => {
-    localStorage.setItem("mc.objLabels.v1", "bogus");
-    expect(loadObjLabelMode()).toBe("all");
+  it("prefers the v2 value over a stale legacy one, and drops v1 on persist", () => {
+    localStorage.setItem(LEGACY_KEY, "none");
+    localStorage.setItem(KEY, "fields");
+    expect(loadObjHidden()).toEqual({ source: false, fields: true, status: false });
+    persistObjHidden({ source: false, fields: true, status: false });
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+  });
+
+  it("falls back to hiding nothing for an unrecognised legacy mode", () => {
+    localStorage.setItem(LEGACY_KEY, "bogus");
+    expect(loadObjHidden()).toEqual(NOTHING_HIDDEN);
   });
 
   it("tolerates a throwing localStorage on persist", () => {
     const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("quota");
     });
-    expect(() => persistObjLabelMode("both")).not.toThrow();
+    expect(() => persistObjHidden(ALL_HIDDEN)).not.toThrow();
     spy.mockRestore();
   });
 });
 
-describe("showInputSource", () => {
-  it("shows the source chip+stripe only in all / noFields", () => {
-    expect(showInputSource("all")).toBe(true);
-    expect(showInputSource("noFields")).toBe(true);
-    expect(showInputSource("noSource")).toBe(false);
-    expect(showInputSource("both")).toBe(false);
+describe("objLabels helpers", () => {
+  it("toggles one part without touching the others", () => {
+    const once = togglePart(NOTHING_HIDDEN, "status");
+    expect(once).toEqual({ source: false, fields: false, status: true });
+    expect(togglePart(once, "fields")).toEqual({ source: false, fields: true, status: true });
+    expect(togglePart(once, "status")).toEqual(NOTHING_HIDDEN);
   });
-});
 
-describe("showFieldCount", () => {
-  it("shows the field count only in all / noSource", () => {
-    expect(showFieldCount("all")).toBe(true);
-    expect(showFieldCount("noSource")).toBe(true);
-    expect(showFieldCount("noFields")).toBe(false);
-    expect(showFieldCount("both")).toBe(false);
+  it("counts hidden parts and recognises the two extremes", () => {
+    expect(hiddenCount(NOTHING_HIDDEN)).toBe(0);
+    expect(hiddenCount(ALL_HIDDEN)).toBe(OBJ_LABEL_PARTS.length);
+    expect(isNothingHidden(NOTHING_HIDDEN)).toBe(true);
+    expect(isAllHidden(ALL_HIDDEN)).toBe(true);
+
+    const one = togglePart(NOTHING_HIDDEN, "source");
+    expect(hiddenCount(one)).toBe(1);
+    expect(isNothingHidden(one)).toBe(false);
+    expect(isAllHidden(one)).toBe(false);
   });
 });

--- a/packages/web/src/state/objLabels.ts
+++ b/packages/web/src/state/objLabels.ts
@@ -1,33 +1,78 @@
 // What each object node shows on the canvas. A per-browser view preference
 // (not model data) — persisted in localStorage, mirroring relLabels/viewMode.
-export type ObjLabelMode = "all" | "noSource" | "noFields" | "both";
+//
+// The parts toggle independently, so any combination is expressible (e.g. keep
+// the field count but drop the status dot). Stored as the set of HIDDEN parts:
+// the empty set means "show everything", and a part added later defaults to
+// visible for everyone who already has a preference stored.
+export type ObjLabelPart = "source" | "fields" | "status";
+export type ObjHidden = Readonly<Record<ObjLabelPart, boolean>>;
 
-const KEY = "mc.objLabels.v1";
-const MODES: readonly ObjLabelMode[] = ["all", "noSource", "noFields", "both"];
+export const OBJ_LABEL_PARTS: readonly ObjLabelPart[] = ["source", "fields", "status"];
 
-export function loadObjLabelMode(): ObjLabelMode {
+export const NOTHING_HIDDEN: ObjHidden = { source: false, fields: false, status: false };
+export const ALL_HIDDEN: ObjHidden = { source: true, fields: true, status: true };
+
+const KEY = "mc.objLabels.v2";
+const LEGACY_KEY = "mc.objLabels.v1";
+
+// v1 stored a single mutually exclusive mode; map each one onto the new set so
+// an existing preference survives the switch to multi-select.
+const LEGACY_MODES: Record<string, ObjHidden> = {
+  all: NOTHING_HIDDEN,
+  noSource: { source: true, fields: false, status: false },
+  noFields: { source: false, fields: true, status: false },
+  noStatus: { source: false, fields: false, status: true },
+  both: { source: true, fields: true, status: false },
+  none: ALL_HIDDEN,
+};
+
+function isPart(v: string): v is ObjLabelPart {
+  return (OBJ_LABEL_PARTS as readonly string[]).includes(v);
+}
+
+function parse(csv: string): ObjHidden {
+  const hidden: Record<ObjLabelPart, boolean> = { ...NOTHING_HIDDEN };
+  for (const token of csv.split(",")) {
+    const part = token.trim();
+    if (isPart(part)) hidden[part] = true;
+  }
+  return hidden;
+}
+
+export function loadObjHidden(): ObjHidden {
   try {
     const v = localStorage.getItem(KEY);
-    return v !== null && MODES.includes(v as ObjLabelMode) ? (v as ObjLabelMode) : "all";
+    if (v !== null) return parse(v);
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (legacy !== null && legacy in LEGACY_MODES) return LEGACY_MODES[legacy];
+    return NOTHING_HIDDEN;
   } catch {
-    return "all";
+    return NOTHING_HIDDEN;
   }
 }
 
-export function persistObjLabelMode(mode: ObjLabelMode): void {
+export function persistObjHidden(hidden: ObjHidden): void {
   try {
-    localStorage.setItem(KEY, mode);
+    localStorage.setItem(KEY, OBJ_LABEL_PARTS.filter(p => hidden[p]).join(","));
+    localStorage.removeItem(LEGACY_KEY); // fully superseded — don't read it again
   } catch {
     // best-effort; ignore quota / private-mode failures
   }
 }
 
-// The source badge and the header accent stripe both encode inputSource colour,
-// so they show/hide together.
-export function showInputSource(mode: ObjLabelMode): boolean {
-  return mode === "all" || mode === "noFields";
+export function hiddenCount(hidden: ObjHidden): number {
+  return OBJ_LABEL_PARTS.filter(p => hidden[p]).length;
 }
 
-export function showFieldCount(mode: ObjLabelMode): boolean {
-  return mode === "all" || mode === "noSource";
+export function isNothingHidden(hidden: ObjHidden): boolean {
+  return hiddenCount(hidden) === 0;
+}
+
+export function isAllHidden(hidden: ObjHidden): boolean {
+  return hiddenCount(hidden) === OBJ_LABEL_PARTS.length;
+}
+
+export function togglePart(hidden: ObjHidden, part: ObjLabelPart): ObjHidden {
+  return { ...hidden, [part]: !hidden[part] };
 }


### PR DESCRIPTION
## Why

The object-labels flyout was a mutually exclusive enum (`all` / `noSource` / `noFields` / `both`), so useful combinations weren't expressible. The trigger: **keep the field count, hide the status dot**. Adding the status dot as another enum value would mean one mode per combination — 8 for three parts.

## What

The setting is now a **set of hidden parts** (`source` / `fields` / `status`), toggled independently.

### `state/objLabels.ts`

- `ObjHidden = Readonly<Record<ObjLabelPart, boolean>>`, storing the **hidden** set — so the empty set means "show everything" and any part added later defaults to visible for people who already have a preference stored.
- Persisted as a CSV of hidden parts under `mc.objLabels.v2`. Legacy `mc.objLabels.v1` modes migrate one-to-one (`both` → source+fields), and the v1 key is removed on the first v2 write.
- Helpers: `togglePart`, `hiddenCount`, `isNothingHidden`, `isAllHidden`, plus `NOTHING_HIDDEN` / `ALL_HIDDEN`.

### Flyout (`Dock.tsx`)

```
OBJECT LABELS
≡  Show everything          <- reset row; highlighted when nothing is hidden
HIDE - PICK ANY
[x] # Input source          <- checkboxes; toggle independently,
[ ] # Field count              menu stays open across clicks
[x] . Status dot
------------------
/  Hide all                 <- highlighted when everything is hidden
```

Both end-state rows carry `aria-pressed` and light up when they describe the current state, so the way into a partial state and the way back to the default are equally visible.

The corner badge on the Add button summarises what's suppressed: `≡` nothing hidden → the part's own glyph when exactly one is → the count (`2`) → `⊘` when all are.

### Other

- `MartNode`: the status dot is now conditional, and got a `data-testid` (it had no accessible name to target).
- `Canvas`: state renamed to `objHidden`, passed into node data as `_objHidden`.

## Verification

- `pnpm --filter @mc/web test` → 53 files, **415 tests passing**. New coverage: all six legacy-v1 migrations and v2-over-v1 precedence; toggling one part without disturbing the others; the menu staying open across toggles; `Show everything` / `Hide all` behaviour and pressed state; all four badge variants; and the previously impossible render combination (source + status hidden, field count kept).
- `tsc --noEmit` clean.
- Verified manually in the local dev app.

Nothing here touches model data: the preference stays per-browser and is absent from the persisted model, the share link and the OKF format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)