### PR TITLE
fix(canvas): flip object-label checkboxes to show-semantics

### DIFF
--- a/packages/web/src/components/canvas/Dock.test.tsx
+++ b/packages/web/src/components/canvas/Dock.test.tsx
@@ -58,20 +58,25 @@ describe("Dock object-labels flyout", () => {
     act(() => { vi.advanceTimersByTime(500); });
   };
 
-  it("opens the flyout 0.5s after hovering Add and lists every hideable part", () => {
+  it("opens the flyout 0.5s after hovering Add with every part ticked by default", () => {
     render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
-    expect(screen.queryByText("Show everything")).toBeNull(); // delay pending
+    expect(screen.queryByText("Input source")).toBeNull(); // delay pending
     openFlyout();
-    expect(screen.getByText("Show everything")).toBeTruthy();
-    expect(screen.getByText("Hide all")).toBeTruthy();
     const boxes = screen.getAllByRole("checkbox");
-    expect(boxes.map(b => b.getAttribute("aria-checked"))).toEqual(["false", "false", "false"]);
+    expect(boxes.map(b => b.getAttribute("aria-checked"))).toEqual(["true", "true", "true"]);
     expect(screen.getByText("Input source")).toBeTruthy();
     expect(screen.getByText("Field count")).toBeTruthy();
     expect(screen.getByText("Status dot")).toBeTruthy();
   });
 
-  it("toggles one part at a time, leaving the others alone", () => {
+  it("reflects a hidden part as an unticked box", () => {
+    render(<Dock {...base} objHidden={{ source: false, fields: false, status: true }} onObjHiddenChange={() => {}} />);
+    openFlyout();
+    expect(screen.getByRole("checkbox", { name: /Status dot/ }).getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByRole("checkbox", { name: /Field count/ }).getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("unticking a part hides it, leaving the others alone", () => {
     const onChange = vi.fn();
     render(<Dock {...base} objHidden={{ source: true, fields: false, status: false }} onObjHiddenChange={onChange} />);
     openFlyout();
@@ -79,11 +84,10 @@ describe("Dock object-labels flyout", () => {
     expect(onChange).toHaveBeenCalledWith({ source: true, fields: false, status: true });
   });
 
-  it("unchecks an already-hidden part", () => {
+  it("re-ticking a part brings it back", () => {
     const onChange = vi.fn();
     render(<Dock {...base} objHidden={{ source: true, fields: false, status: true }} onObjHiddenChange={onChange} />);
     openFlyout();
-    expect(screen.getByRole("checkbox", { name: /Status dot/ }).getAttribute("aria-checked")).toBe("true");
     fireEvent.click(screen.getByRole("checkbox", { name: /Status dot/ }));
     expect(onChange).toHaveBeenCalledWith({ source: true, fields: false, status: false });
   });
@@ -92,12 +96,12 @@ describe("Dock object-labels flyout", () => {
     render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
     openFlyout();
     fireEvent.click(screen.getByRole("checkbox", { name: /Field count/ }));
-    expect(screen.getByText("Show everything")).toBeTruthy();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
     fireEvent.click(screen.getByRole("checkbox", { name: /Status dot/ }));
     expect(screen.getAllByRole("checkbox")).toHaveLength(3);
   });
 
-  it("resets to nothing hidden via Show everything, and hides everything via Hide all", () => {
+  it("ticks everything back on via the check-all row, and clears it via uncheck-all", () => {
     const onChange = vi.fn();
     render(<Dock {...base} objHidden={ALL_HIDDEN} onObjHiddenChange={onChange} />);
     openFlyout();
@@ -108,7 +112,7 @@ describe("Dock object-labels flyout", () => {
     expect(onChange).toHaveBeenLastCalledWith(ALL_HIDDEN);
   });
 
-  it("marks Show everything as the active row when nothing is hidden", () => {
+  it("marks the check-all row as active when nothing is hidden", () => {
     render(<Dock {...base} objHidden={NOTHING_HIDDEN} onObjHiddenChange={() => {}} />);
     openFlyout();
     expect(screen.getByTestId("obj-label-reset").getAttribute("aria-pressed")).toBe("true");

--- a/packages/web/src/components/canvas/Dock.tsx
+++ b/packages/web/src/components/canvas/Dock.tsx
@@ -238,8 +238,9 @@ function ConnectToolButton({
 // "Object labels" view setting and an always-visible corner badge summarising
 // what's hidden. Clicking the button activates the Add tool; the flyout
 // (revealed after ~0.5s hover) is a separate, view-only control. The flyout is
-// multi-select: each part toggles on its own and the menu stays open, with
-// "Show everything" as the always-visible way back to the default.
+// multi-select and phrased as what's SHOWN: every box starts ticked, unticking
+// one hides that part, and the menu stays open so several can be picked. Two
+// shortcut rows cover the extremes (check all / uncheck all).
 function AddObjectToolButton({
   active,
   onActivate,
@@ -303,38 +304,28 @@ function AddObjectToolButton({
               Object labels
             </div>
 
-            {/* Reset row: shows the current state when nothing is hidden and is
-                the one-click way back to it otherwise. */}
-            <button
-              data-testid="obj-label-reset"
-              aria-pressed={nothingHidden}
-              onClick={() => onObjHiddenChange?.(NOTHING_HIDDEN)}
-              className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${nothingHidden ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
-            >
-              <span className={`w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-400"}`}>≡</span>
-              <span className={`text-[13px] font-semibold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Show everything</span>
-            </button>
-
-            <div className="px-2 pt-2 pb-1 text-[10.5px] font-semibold uppercase tracking-wide text-slate-400">
-              Hide — pick any
+            <div className="px-2 pb-1.5 text-[11px] leading-snug text-slate-500">
+              Tick what every object shows — untick to hide it.
             </div>
 
+            {/* A checked box means the part is VISIBLE — unchecking hides it.
+                The stored state is the hidden set, hence the inversion here. */}
             {OBJ_LABEL_PARTS.map(part => {
               const meta = OBJ_PART_META[part];
-              const checked = objHidden[part];
+              const shown = !objHidden[part];
               return (
                 <button
                   key={part}
                   role="checkbox"
-                  aria-checked={checked}
+                  aria-checked={shown}
                   onClick={() => onObjHiddenChange?.(togglePart(objHidden, part))}
-                  className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${checked ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+                  className="flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[#f1f3f7]"
                 >
-                  <span className={`mt-[2px] flex h-[14px] w-[14px] flex-shrink-0 items-center justify-center rounded-[4px] border transition-colors ${checked ? "border-[#1e88e5] bg-[#1e88e5] text-white" : "border-slate-300 bg-white text-transparent"}`}>
+                  <span className={`mt-[2px] flex h-[14px] w-[14px] flex-shrink-0 items-center justify-center rounded-[4px] border transition-colors ${shown ? "border-[#1e88e5] bg-[#1e88e5] text-white" : "border-slate-300 bg-white text-transparent"}`}>
                     <Check size={10} strokeWidth={3.5} />
                   </span>
                   <span className="flex flex-col">
-                    <span className={`text-[13px] font-semibold ${checked ? "text-[#1e88e5]" : "text-slate-800"}`}>
+                    <span className={`text-[13px] font-semibold ${shown ? "text-slate-800" : "text-slate-400"}`}>
                       <span className="mr-1 font-bold text-slate-400">{meta.glyph}</span>
                       {meta.label}
                     </span>
@@ -344,7 +335,18 @@ function AddObjectToolButton({
               );
             })}
 
+            {/* Both-ends shortcuts: tick everything back on, or clear it all. */}
             <div className="mt-1 border-t border-[#eef1f5] pt-1">
+              <button
+                data-testid="obj-label-reset"
+                aria-pressed={nothingHidden}
+                onClick={() => onObjHiddenChange?.(NOTHING_HIDDEN)}
+                className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${nothingHidden ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
+              >
+                <span className={`w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-400"}`}>≡</span>
+                <span className={`text-[13px] font-semibold ${nothingHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Check all — show everything</span>
+              </button>
+
               <button
                 data-testid="obj-label-hide-all"
                 aria-pressed={allHidden}
@@ -352,7 +354,7 @@ function AddObjectToolButton({
                 className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${allHidden ? "bg-[#e6f1fb]" : "hover:bg-[#f1f3f7]"}`}
               >
                 <span className={`w-[16px] flex-shrink-0 text-center text-[12px] font-bold ${allHidden ? "text-[#1e88e5]" : "text-slate-400"}`}>⊘</span>
-                <span className={`text-[13px] font-semibold ${allHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Hide all</span>
+                <span className={`text-[13px] font-semibold ${allHidden ? "text-[#1e88e5]" : "text-slate-800"}`}>Uncheck all — title only</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
Follow-up to #38.

## Why

In #38 a ticked box meant "hide this part", which fights intuition — a checkmark reads as "this is on". It also meant the default state (nothing hidden) rendered every row unticked, and conversely any active row was tinted blue, so hiding all three lit up the whole menu.

## What

The flyout is now phrased as what's **shown**:

```
OBJECT LABELS
Tick what every object shows — untick to hide it.
[x] # Input source     The source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent stripe
[x] # Field count      The field-count line under each object
[x] . Status dot       The push-status dot in the object's top-right corner
--------------------
=  Check all - show everything      <- highlighted when everything is visible
/  Uncheck all - title only         <- highlighted when everything is hidden
```

- All three boxes start ticked; unticking one hides that part.
- Rows are no longer tinted when active — only the box is blue, and an unticked row's label fades to `slate-400`. Blue tint is reserved for whichever shortcut row matches the current state.
- The two extremes now sit together below the boxes as a pair, both with `aria-pressed`.
- A hint line under the title names the polarity outright.

The stored state is unchanged: still the **hidden** set under `mc.objLabels.v2`, so the empty set means "show everything" and any part added later defaults to visible. The inversion lives only in the row render (`const shown = !objHidden[part]`), with a comment saying so.

## Verification

- `pnpm --filter @mc/web test` → 53 files, **416 tests passing**. The object-labels Dock cases were rewritten for the new polarity: default `aria-checked` is `["true","true","true"]`, a hidden part renders as an unticked box, unticking hides / re-ticking restores, and the check-all / uncheck-all rows fire `NOTHING_HIDDEN` / `ALL_HIDDEN`.
- `tsc --noEmit` clean.
- Verified manually in the local dev app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)