### PR TITLE
feat(okf): optional Alias column in the # Schema table

### DIFF
--- a/packages/okf/src/parse.ts
+++ b/packages/okf/src/parse.ts
@@ -151,7 +151,13 @@ function parseOverview(body: string): { id?: string; status?: string; definition
 
 function parseSchema(body: string): import("./types").SchemaField[] {
   const out: import("./types").SchemaField[] = [];
-  const lines = body.split("\n"); let inSchema = false; let legacy = false;
+  const lines = body.split("\n"); let inSchema = false;
+  // Column positions come from the header row, so the canonical
+  // `| Column | Type | Description |` form, the optional-Alias form, and the
+  // legacy `| Column | Type | PK | Alias | Description |` form all parse
+  // without guessing at the arity. Description falls back to index 2 for
+  // tables written without a header.
+  let idxPk = -1, idxAlias = -1, idxDesc = 2;
   for (const ln of lines) {
     if (/^##?\s+Schema/i.test(ln)) { inSchema = true; continue; }
     if (!inSchema) continue;
@@ -160,23 +166,22 @@ function parseSchema(body: string): import("./types").SchemaField[] {
     const cells = ln.split("|").slice(1, -1).map(c => c.trim());
     if (cells.length < 2) continue;
     const name = cells[0].replace(/`/g, "").trim();
-    if (!name || name === "Column") {
-      legacy = cells.some(c => /^pk$/i.test(c) || /^alias$/i.test(c)); // header row
+    if (!name || /^column$/i.test(name)) { // header row
+      idxPk = cells.findIndex(c => /^pk$/i.test(c));
+      idxAlias = cells.findIndex(c => /^alias$/i.test(c));
+      const d = cells.findIndex(c => /^description$/i.test(c));
+      idxDesc = d >= 0 ? d : (idxPk === 2 || idxAlias === 2 ? -1 : 2);
       continue;
     }
     if (/^:?-+:?$/.test(name)) continue; // separator
     const type = (cells[1] || "STRING").replace(/`/g, "").trim() || "STRING";
     const field: import("./types").SchemaField = { name, type, pk: false };
-    if (legacy) {
-      field.pk = /^(✓|x|X)$/.test((cells[2] || "").trim());
-      const alias = (cells[3] || "").trim(); const desc = (cells[4] || "").trim();
-      if (alias) field.alias = alias;
-      if (desc) field.description = desc;
-    } else {
-      let desc = (cells[2] || "").trim();
-      if (/^PK\.\s*/.test(desc)) { field.pk = true; desc = desc.replace(/^PK\.\s*/, "").trim(); }
-      if (desc) field.description = desc;
-    }
+    if (idxPk >= 0) field.pk = /^(✓|x|X)$/.test((cells[idxPk] || "").trim());
+    let desc = (idxDesc >= 0 ? cells[idxDesc] || "" : "").trim();
+    if (/^PK\.\s*/.test(desc)) { field.pk = true; desc = desc.replace(/^PK\.\s*/, "").trim(); }
+    const alias = (idxAlias >= 0 ? cells[idxAlias] || "" : "").replace(/`/g, "").trim();
+    if (alias) field.alias = alias;
+    if (desc) field.description = desc;
     out.push(field);
   }
   if (out.length === 0) return parseSchemaBullets(body);

--- a/packages/okf/src/serialize.ts
+++ b/packages/okf/src/serialize.ts
@@ -56,15 +56,24 @@ function renderNode(n: ModelNode, g: ModelGraph, slugByKey: Map<string, string>)
   ].join("\n");
 
   const fk = fkColumns(n, g, slugByKey);
+  // The Alias column is emitted only when some field has one, so marts without
+  // aliases keep the leaner 3-column table.
+  const withAlias = n.schema.some(f => f.alias);
+  const header = withAlias
+    ? "| Column | Type | Alias | Description |\n|--------|------|-------|-------------|\n"
+    : "| Column | Type | Description |\n|--------|------|-------------|\n";
   const schema = n.schema.length
-    ? "# Schema\n\n| Column | Type | Description |\n|--------|------|-------------|\n" +
+    ? "# Schema\n\n" + header +
       n.schema.map(f => {
         const parts: string[] = [];
         if (f.pk) parts.push("PK.");
         if (f.description) parts.push(f.description);
         const ref = fk.get(f.name);
         if (ref) parts.push(`FK to [${ref.title}](./${ref.slug}.md)`);
-        return `| \`${f.name}\` | ${f.type} | ${parts.join(" ").trim()} |`;
+        const cells = withAlias
+          ? [`\`${f.name}\``, f.type, f.alias ?? "", parts.join(" ").trim()]
+          : [`\`${f.name}\``, f.type, parts.join(" ").trim()];
+        return `| ${cells.join(" | ")} |`;
       }).join("\n") + "\n\n"
     : "";
 

--- a/packages/okf/test/roundtrip.test.ts
+++ b/packages/okf/test/roundtrip.test.ts
@@ -25,7 +25,7 @@ describe("okf round-trip", () => {
     expect(back.edges).toHaveLength(1);
     expect(back.edges[0]).toMatchObject({ from: "facebook-ads", to: "campaigns", keys: [{ left: "campaign_id", right: "id" }] });
   });
-  it("round-trips per-field description (alias is not preserved in the superset format), and reads the legacy 3-column form", () => {
+  it("round-trips per-field description and alias, and reads the legacy 3-column form", () => {
     const g: ModelGraph = {
       storageId: null,
       nodes: [{
@@ -37,16 +37,42 @@ describe("okf round-trip", () => {
       }],
       edges: [],
     };
-    const back = parseBundle(serializeBundle(g, "P").files);
+    const files = serializeBundle(g, "P").files;
+    expect(files["p/users.md"]).toContain("| Column | Type | Alias | Description |");
+    const back = parseBundle(files);
     expect(back.nodes[0].schema).toEqual([
-      { name: "id", type: "STRING", pk: true, description: "Unique id" },
+      { name: "id", type: "STRING", pk: true, alias: "user_id", description: "Unique id" },
       { name: "email", type: "STRING", pk: false },
     ]);
+    // No aliases anywhere → the leaner 3-column table.
+    const plain = serializeBundle(
+      { ...g, nodes: [{ ...g.nodes[0], schema: [{ name: "id", type: "STRING", pk: true }] }] },
+      "P",
+    ).files;
+    expect(plain["p/users.md"]).toContain("| Column | Type | Description |");
     // Legacy 3-column table still imports.
     const legacy = parseBundle({
       "p/a.md": frontless("a", "A") + "\n## Schema\n\n| Column | Type | PK |\n|--|--|--|\n| `x` | INTEGER | ✓ |\n",
     });
     expect(legacy.nodes[0].schema).toEqual([{ name: "x", type: "INTEGER", pk: true }]);
+    // Legacy 5-column table keeps its own PK/Alias columns.
+    const legacy5 = parseBundle({
+      "p/b.md": frontless("b", "B") +
+        "\n## Schema\n\n| Column | Type | PK | Alias | Description |\n|--|--|--|--|--|\n| `x` | INTEGER | ✓ | X id | The id |\n",
+    });
+    expect(legacy5.nodes[0].schema).toEqual([
+      { name: "x", type: "INTEGER", pk: true, alias: "X id", description: "The id" },
+    ]);
+    // Hand-authored 4-column form: Alias plus the `PK.` description marker.
+    const authored = parseBundle({
+      "p/c.md": frontless("c", "C") +
+        "\n# Schema\n\n| Column | Type | Alias | Description |\n|--|--|--|--|\n" +
+        "| `id` | STRING | Order ID | PK. Unique order id |\n| `total` | FLOAT | | Gross total |\n",
+    });
+    expect(authored.nodes[0].schema).toEqual([
+      { name: "id", type: "STRING", pk: true, alias: "Order ID", description: "Unique order id" },
+      { name: "total", type: "FLOAT", pk: false, description: "Gross total" },
+    ]);
   });
 
   it("collapses mutual Joins lines into one bidirectional edge", () => {

--- a/packages/web/public/ai-instructions.html
+++ b/packages/web/public/ai-instructions.html
@@ -182,6 +182,13 @@ SELECT id, customer_id, order_date, total FROM `project.dataset.orders`
       </ul>
     </li>
   </ul>
+  <p>Optionally add a 4th <code>Alias</code> column — a business-friendly label for the field. Put it between <code>Type</code> and <code>Description</code> and leave the cell empty for fields that don't need one. The canvas shows the alias instead of the raw column name on the node and pushes it to OWOX; <b>Export OKF</b> emits this column only when at least one field has an alias.</p>
+<pre><code># Schema
+
+| Column | Type | Alias | Description |
+|--------|------|-------|-------------|
+| `id` | STRING | | PK. Unique order identifier |
+| `total` | FLOAT | Order Total | Order total, gross |</code></pre>
   <p><b>Allowed types</b> (cross-storage canonical set — do not use others like <code>DATETIME</code>):</p>
   <p><span class="chip">STRING</span><span class="chip">INTEGER</span><span class="chip">FLOAT</span><span class="chip">NUMERIC</span><span class="chip">BOOLEAN</span><span class="chip">DATE</span><span class="chip">TIME</span><span class="chip">TIMESTAMP</span><span class="chip">BYTES</span><span class="chip">GEOGRAPHY</span><span class="chip">VARIANT</span></p>
 

--- a/packages/web/public/okf-format.md
+++ b/packages/web/public/okf-format.md
@@ -110,9 +110,16 @@ SELECT id, customer_id, order_date, total FROM `project.dataset.orders`
 - Leave `**ID:**` and `**Storage:**` as `—` — the canvas fills them.
 
 ### `# Schema` (the mart's output fields)
-A 3-column table: **Column** (name in backticks), **Type**, **Description**.
+A 3-column table: **Column** (name in backticks), **Type**, **Description** — plus an optional **Alias** column (see below).
 - **Primary key:** start the Description with `PK.` — e.g. `PK. Unique id`. Mark exactly one PK per mart.
 - **Foreign key:** write `FK to [Target Title](./target-slug.md)` in the Description. (Helps relationships and documentation.)
+- **Alias (optional):** add a 4th **Alias** column for a business-friendly field label — `| Column | Type | Alias | Description |`. Leave the cell empty for fields that don't need one. The canvas shows the alias instead of the raw column name on the node, and pushes it to OWOX. Export OKF only emits this column when at least one field has an alias.
+  ```
+  | Column | Type | Alias | Description |
+  |--------|------|-------|-------------|
+  | `id` | STRING | | PK. Unique order identifier |
+  | `total` | FLOAT | Order Total | Order total, gross |
+  ```
 - **Allowed types only** (cross-storage set — do NOT use others like DATETIME):
   `STRING` `INTEGER` `FLOAT` `NUMERIC` `BOOLEAN` `DATE` `TIME` `TIMESTAMP` `BYTES` `GEOGRAPHY` `VARIANT`
 


### PR DESCRIPTION
## What & why

Field aliases were a first-class concept everywhere except the file format: editable in the inspector (`SchemaEditor.tsx`), pushed to OWOX (`push.ts`), read back on OWOX import (`owoxImport.ts`) — but the canonical 3-column `| Column | Type | Description |` table had nowhere to put one.

Consequences:
- an alias set on the canvas was **silently dropped** by Export OKF (a test even pinned this: *"alias is not preserved in the superset format"*);
- an AI agent generating a bundle from our authoring guide had **no way** to specify one.

## Changes

**Schema tables are parsed by header name rather than by position** (`packages/okf/src/parse.ts`). One code path now covers every form:

| Header | PK comes from | Alias |
|---|---|---|
| `Column \| Type \| Description` | `PK.` prefix | — |
| `Column \| Type \| Alias \| Description` **(new)** | `PK.` prefix | Alias column |
| `Column \| Type \| PK \| Alias \| Description` (legacy) | PK column | Alias column |
| no header row | `PK.` prefix | — |

This also fixes a quiet corruption: the word "Alias" in a header used to flip the parser into legacy mode, so a 4-column table had its PK read from the Alias column and its alias read from the Description column.

**Serialization** (`packages/okf/src/serialize.ts`) emits the `Alias` column only when at least one field has an alias. Bundles without aliases — the `OWOX/models` library, the worked examples in the guide — round-trip byte-identically. An alias is no longer lost on the canvas → Export OKF → Import → Push path.

**Documentation** — updated in both authoring guides, since they are separate files:
- `packages/web/public/ai-instructions.html` — the "4. Output schema (fields)" section, plus an example table;
- `packages/web/public/okf-format.md` — the same for agents and for the Import dialog, which fetches this file.

```
# Schema

| Column | Type | Alias | Description |
|--------|------|-------|-------------|
| `id` | STRING | | PK. Unique order identifier |
| `total` | FLOAT | Order Total | Order total, gross |
```

The column is optional: leave the cell empty for fields that don't need a label.

## Compatibility

Backward compatible in both directions. Existing 3-column and legacy 5-column bundles parse as before, and export output is unchanged for marts without aliases.

## Verification

```
pnpm -r test  → 509 passed (okf 54, server 36, web 419)
pnpm build    → ok
```

New cases in `roundtrip.test.ts`: alias round-trip, the 4-column form combined with the `PK.` marker, the legacy 5-column form, the legacy `| Column | Type | PK |` form with no Description, and that the header stays 3-column when no field has an alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
