### PR TITLE
feat(push): force push marts that already exist in OWOX

### DIFF
--- a/packages/web/src/components/PushConfirmDialog.test.tsx
+++ b/packages/web/src/components/PushConfirmDialog.test.tsx
@@ -5,12 +5,14 @@ import { PushConfirmDialog } from "./PushConfirmDialog";
 const base = {
   projectTitle: "MCP Demo",
   storage: { title: "BigQuery EU", type: "GOOGLE_BIGQUERY" },
-  counts: { marts: 3, relationships: 2 },
+  counts: { marts: 3, relationships: 2, alreadyPushed: 0 },
 };
+
+const noop = { onConfirm: () => {}, onForcePush: () => {}, onChangeProject: () => {}, onClose: () => {} };
 
 describe("PushConfirmDialog", () => {
   it("shows the target project, storage and counts", () => {
-    render(<PushConfirmDialog {...base} onConfirm={() => {}} onChangeProject={() => {}} onClose={() => {}} />);
+    render(<PushConfirmDialog {...base} {...noop} />);
     expect(screen.getByText("MCP Demo")).toBeTruthy();
     expect(screen.getByText(/BigQuery EU/)).toBeTruthy();
     expect(screen.getByText(/GOOGLE_BIGQUERY/)).toBeTruthy();
@@ -19,12 +21,45 @@ describe("PushConfirmDialog", () => {
 
   it("wires Push, Change project and Cancel", () => {
     const onConfirm = vi.fn(), onChangeProject = vi.fn(), onClose = vi.fn();
-    render(<PushConfirmDialog {...base} onConfirm={onConfirm} onChangeProject={onChangeProject} onClose={onClose} />);
+    render(<PushConfirmDialog {...base} onConfirm={onConfirm} onForcePush={() => {}} onChangeProject={onChangeProject} onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /^push$/i }));
     fireEvent.click(screen.getByRole("button", { name: /change project/i }));
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onChangeProject).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the force-push escape hatch when nothing is being skipped", () => {
+    render(<PushConfirmDialog {...base} {...noop} />);
+    expect(screen.queryByRole("button", { name: /force push/i })).toBeNull();
+  });
+
+  it("explains the skipped marts and offers force push when some are already in OWOX", () => {
+    render(<PushConfirmDialog {...base} counts={{ marts: 0, relationships: 0, alreadyPushed: 12 }} {...noop} />);
+    expect(screen.getByText(/12 marts are already created in this project/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /force push to owox again/i })).toBeTruthy();
+  });
+
+  it("calls onForcePush — not onConfirm — from the force button", () => {
+    const onConfirm = vi.fn(), onForcePush = vi.fn();
+    render(
+      <PushConfirmDialog
+        {...base}
+        counts={{ marts: 0, relationships: 0, alreadyPushed: 2 }}
+        onConfirm={onConfirm}
+        onForcePush={onForcePush}
+        onChangeProject={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /force push to owox again/i }));
+    expect(onForcePush).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("disables Push when there is nothing left to push", () => {
+    render(<PushConfirmDialog {...base} counts={{ marts: 0, relationships: 0, alreadyPushed: 4 }} {...noop} />);
+    expect(screen.getByRole("button", { name: /^push$/i })).toHaveProperty("disabled", true);
   });
 });

--- a/packages/web/src/components/PushConfirmDialog.tsx
+++ b/packages/web/src/components/PushConfirmDialog.tsx
@@ -1,8 +1,9 @@
 interface PushConfirmDialogProps {
   projectTitle?: string;
   storage?: { title: string; type: string } | null;
-  counts: { marts: number; relationships: number };
+  counts: { marts: number; relationships: number; alreadyPushed: number };
   onConfirm: () => void;        // proceed with the push
+  onForcePush: () => void;      // push again, re-creating marts already in OWOX
   onChangeProject: () => void;  // sign out (detaches from OWOX) + open sign-in
   onClose: () => void;          // cancel
 }
@@ -10,7 +11,12 @@ interface PushConfirmDialogProps {
 // Confirmation before pushing: shows exactly which project + storage the marts
 // will land in (the user kept pushing to the wrong storage), plus how many marts
 // and relationships will be sent. "Change project" detaches and re-signs-in.
-export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, onChangeProject, onClose }: PushConfirmDialogProps) {
+export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, onForcePush, onChangeProject, onClose }: PushConfirmDialogProps) {
+  // Marts already created in this project are skipped, which makes a plain push a
+  // no-op — misleading unless we say so. The escape hatch lives inside the warning
+  // (the button row is already full) and needs no second confirmation: this block
+  // IS the confirmation.
+  const nothingToPush = counts.marts === 0 && counts.relationships === 0;
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
@@ -40,6 +46,25 @@ export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, on
           {counts.marts} {counts.marts === 1 ? "mart" : "marts"} and {counts.relationships} {counts.relationships === 1 ? "relationship" : "relationships"} will be pushed.
         </p>
 
+        {counts.alreadyPushed > 0 && (
+          <div className="flex flex-col gap-2.5 rounded-lg border border-[#f0c88a] bg-[#fdf6e7] px-4 py-3">
+            <p className="text-[13px] leading-[1.45] text-[#8a5a00]">
+              <span className="font-semibold">
+                {counts.alreadyPushed} {counts.alreadyPushed === 1 ? "mart is" : "marts are"} already created in this project
+              </span>
+              , so {counts.alreadyPushed === 1 ? "it is" : "they are"} skipped. Deleted {counts.alreadyPushed === 1 ? "it" : "them"} in OWOX?
+              Force-push to create {counts.alreadyPushed === 1 ? "it" : "them"} again — if {counts.alreadyPushed === 1 ? "it is" : "they are"} still
+              there, OWOX will report a duplicate.
+            </p>
+            <button
+              onClick={onForcePush}
+              className="self-end text-[13px] font-[550] border border-[#e0a94a] bg-white text-[#8a5a00] rounded-lg px-3 py-[7px] cursor-pointer hover:bg-[#fbeed3]"
+            >
+              Force push to OWOX again
+            </button>
+          </div>
+        )}
+
         <div className="flex items-center justify-between gap-2">
           <button
             onClick={onChangeProject}
@@ -56,7 +81,8 @@ export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, on
             </button>
             <button
               onClick={onConfirm}
-              className="text-[13px] font-[550] bg-[#1e88e5] text-white border border-[#1e88e5] rounded-lg px-4 py-[7px] cursor-pointer hover:bg-[#1976d2]"
+              disabled={nothingToPush}
+              className="text-[13px] font-[550] bg-[#1e88e5] text-white border border-[#1e88e5] rounded-lg px-4 py-[7px] cursor-pointer hover:bg-[#1976d2] disabled:opacity-45 disabled:cursor-not-allowed disabled:hover:bg-[#1e88e5]"
             >
               Push
             </button>

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -35,7 +35,7 @@ import { buildShareUrl, readSharedModel, readSharedName, clearSharedModelFromUrl
 import { readTemplateModel, clearTemplateFromUrl } from "../../lib/templateLink";
 import { readOkfImportUrl, clearOkfFromUrl } from "../../share/okfLink";
 import { exportCanvasSvg } from "../../share/exportImage";
-import { pushModel, pushPreview, type PushResult } from "../../sync/push";
+import { pushModel, pushPreview, type PushResult, type PushOptions } from "../../sync/push";
 import { detachFromOwox } from "../../sync/detach";
 
 import { api } from "../../lib/api";
@@ -739,12 +739,12 @@ function CanvasInner() {
     setShowLibrary(false);
   }, [pendingTemplate, applyTemplate]);
 
-  const runPush = useCallback(async (storagesList: StorageOption[] = storages) => {
+  const runPush = useCallback(async (storagesList: StorageOption[] = storages, opts?: PushOptions) => {
     setPushResult(null);
     setPushing(true);
     try {
       const storageType = storagesList.find(s => s.id === store.get().storageId)?.type;
-      const result = await pushModel(store, undefined, storageType);
+      const result = await pushModel(store, undefined, storageType, opts);
       setPushResult(result);
     } catch (e) {
       setPushResult({ created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [(e as Error).message] });
@@ -855,6 +855,7 @@ function CanvasInner() {
           storage={storages.find(s => s.id === graph.storageId) ?? null}
           counts={pushPreview(graph, graph.storageId)}
           onConfirm={() => { setShowPushConfirm(false); void runPush(); }}
+          onForcePush={() => { setShowPushConfirm(false); void runPush(storages, { force: true }); }}
           onChangeProject={handleChangeProject}
           onClose={() => setShowPushConfirm(false)}
         />

--- a/packages/web/src/sync/push.ts
+++ b/packages/web/src/sync/push.ts
@@ -18,7 +18,9 @@ export interface PushResult {
 // logic so the confirmation dialog's counts match reality. A mart is "already
 // live here" when it's created AND tagged to the active storage; such marts are
 // skipped. An imported (existing) edge is skipped only when both endpoints stay.
-export function pushPreview(graph: ModelGraph, storageId: string | null): { marts: number; relationships: number } {
+// alreadyPushed reports how many marts the skip swallows, so the dialog can say
+// why a push would send nothing and offer a force push instead.
+export function pushPreview(graph: ModelGraph, storageId: string | null): { marts: number; relationships: number; alreadyPushed: number } {
   const liveHere = (n: ModelNode) => n.status === "created" && n.owoxStorageId === storageId;
   const skipped = new Set(graph.nodes.filter(liveHere).map(n => n.key));
   const marts = graph.nodes.filter(n => !skipped.has(n.key)).length;
@@ -27,7 +29,7 @@ export function pushPreview(graph: ModelGraph, storageId: string | null): { mart
     if (e.existing && skipped.has(e.from) && skipped.has(e.to)) continue;
     relationships++;
   }
-  return { marts, relationships };
+  return { marts, relationships, alreadyPushed: skipped.size };
 }
 
 // OWOX validates the output schema with a discriminator keyed on the storage
@@ -44,7 +46,16 @@ function schemaDiscriminator(storageType: string): string {
   return `${base}-data-mart-schema`;
 }
 
-export async function pushModel(store: ModelStore, api: Api = defaultApi, storageType?: string): Promise<PushResult> {
+export interface PushOptions {
+  /** Re-create marts that are already live in the active storage. For the case
+   *  where the user deleted them inside OWOX and wants the same model back: the
+   *  stored owoxId points at a mart that no longer exists, so skipping it would
+   *  silently push nothing. If a mart is in fact still there, OWOX answers with
+   *  an error, which lands on the node like any other push failure. */
+  force?: boolean;
+}
+
+export async function pushModel(store: ModelStore, api: Api = defaultApi, storageType?: string, opts: PushOptions = {}): Promise<PushResult> {
   const res: PushResult = { created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [] };
 
   const storageId = store.get().storageId;
@@ -76,10 +87,12 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
   // Track marts we skip because they already exist IN THIS STORAGE — a "created"
   // mart whose owoxStorageId points at a different storage (e.g. imported from
   // another project, then signed into this one) is NOT in the active storage, so
-  // it must be recreated here rather than silently skipped.
+  // it must be recreated here rather than silently skipped. A forced push skips
+  // nothing: every mart is created again (and so is every relationship, since
+  // the edge skip below keys off this same set).
   const skippedKeys = new Set<string>();
   for (const n of store.get().nodes) {
-    if (n.status === "created" && n.owoxStorageId === storageId) { skippedKeys.add(n.key); continue; }
+    if (!opts.force && n.status === "created" && n.owoxStorageId === storageId) { skippedKeys.add(n.key); continue; }
     store.updateNode(n.key, { status: "creating", error: null });
     try {
       // Create a draft with just { title, storageId } — confirmed to always 201.

--- a/packages/web/test/push.test.ts
+++ b/packages/web/test/push.test.ts
@@ -37,6 +37,17 @@ describe("pushPreview", () => {
     });
     expect(pushPreview(staleEnd, "st_1").relationships).toBe(1);
   });
+  it("reports how many marts are already live here, so the dialog can explain the skip", () => {
+    const live = { inputSource: "SQL" as const, schema: [], position: { x: 0, y: 0 }, status: "created" as const };
+    const g = mk({ nodes: [
+      { key: "n1", title: "A", ...live, owoxId: "a", owoxStorageId: "st_1" },
+      { key: "n2", title: "B", ...live, owoxId: "b", owoxStorageId: "st_1" },
+      { key: "n3", title: "C", ...live, owoxId: "c", owoxStorageId: "OLD" }, // other storage → not "already pushed here"
+      { key: "n4", title: "D", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "pending" },
+    ] });
+    expect(pushPreview(g, "st_1").alreadyPushed).toBe(2);
+    expect(pushPreview(g, "st_1").marts).toBe(2); // n3 + n4
+  });
 });
 
 describe("pushModel", () => {
@@ -205,6 +216,60 @@ describe("pushModel", () => {
     // Marts were recreated in stor_NEW, so the join doesn't exist there yet → must be pushed.
     expect(relationshipCalls.length).toBeGreaterThan(0);
     expect(res.relationshipsCreated).toBeGreaterThan(0);
+  });
+
+  it("force re-creates a mart already live in the active storage (deleted in OWOX)", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "gone_id", owoxStorageId: "stor_1" },
+      ],
+      edges: [],
+    });
+    const calls: string[] = [];
+    const apiMock = vi.fn(async (path: string) => { calls.push(path); return { id: "fresh_id" }; });
+    const res = await pushModel(s, apiMock as any, undefined, { force: true });
+    expect(calls).toContain("/api/data-marts");
+    expect(res.created).toBe(1);
+    expect(s.get().nodes[0].owoxId).toBe("fresh_id"); // the old id pointed at a deleted mart
+    expect(s.get().nodes[0].status).toBe("created");
+  });
+
+  it("force pushes an existing edge whose both endpoints are live here", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [{ name: "customer_id", type: "STRING", pk: false }], position: { x: 0, y: 0 }, status: "created", owoxId: "old_a", owoxStorageId: "stor_1" },
+        { key: "n2", title: "Customers", inputSource: "SQL", schema: [{ name: "id", type: "STRING", pk: true }], position: { x: 100, y: 0 }, status: "created", owoxId: "old_b", owoxStorageId: "stor_1" },
+      ],
+      edges: [
+        { id: "e1", from: "n1", to: "n2", keys: [{ left: "customer_id", right: "id" }], bidirectional: false, existing: true },
+      ],
+    });
+    const relationshipCalls: string[] = [];
+    const apiMock = vi.fn(async (path: string) => { if (path.includes("/relationships")) relationshipCalls.push(path); return { id: "x" }; });
+    const res = await pushModel(s, apiMock as any, undefined, { force: true });
+    expect(relationshipCalls).toHaveLength(1);
+    expect(res.relationshipsCreated).toBe(1);
+  });
+
+  it("force surfaces an OWOX error when the mart still exists there", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "still_there", owoxStorageId: "stor_1" },
+      ],
+      edges: [],
+    });
+    const apiMock = vi.fn(async () => { throw new Error("Data mart with this title already exists"); });
+    const res = await pushModel(s, apiMock as any, undefined, { force: true });
+    expect(res.created).toBe(0);
+    expect(res.failed).toBe(1);
+    expect(s.get().nodes[0].status).toBe("error");
+    expect(res.errors[0]).toMatch(/already exists/);
   });
 
   it("uses an underscore identifier (not a hyphenated slug) for targetAlias", async () => {


### PR DESCRIPTION
## Problem

After a successful push, every data mart turns green — `status: "created"` plus `owoxStorageId` tagged to the active storage — and from then on both `pushPreview()` and `pushModel()` skip it (`packages/web/src/sync/push.ts`).

That's correct in the common case, but it strands a real scenario: the user deletes the Data Marts inside OWOX and wants the same model pushed again. Today `Push to OWOX` looks enabled, sends nothing, and never explains why. The skip is invisible.

## Solution

The confirmation dialog now explains the skip and offers an explicit escape hatch.

- `pushPreview()` reports `alreadyPushed` — how many marts the skip swallows.
- `pushModel(store, api, storageType, { force: true })` leaves `skippedKeys` empty, so every mart is created again (getting a **new** `owoxId` — the stored one points at a mart that no longer exists) and every `existing` relationship is pushed along with it.
- `PushConfirmDialog` renders an amber block when `alreadyPushed > 0`, with `Force push to OWOX again` inside it. No second confirmation step: the block *is* the confirmation, and the 460px button row already holds Change project / Cancel / Push.
- The primary `Push` button is now `disabled` when nothing is left to push — previously it looked active while doing nothing.

If a mart is in fact still in OWOX, the API answers with an error that lands on the node like any other push failure — red status plus the message in `PushToast`. No new error handling needed.

Force applies to all green marts at once. Per-mart selection (checkboxes, or a re-push action in the Inspector) was considered and dropped as YAGNI; the tradeoff is that if only some marts were deleted in OWOX, the rest come back as duplicate errors, which the warning text says out loud.

## Tests

`packages/web/test/push.test.ts`
- force re-creates a mart already live in the active storage (new `owoxId`)
- force pushes an `existing` edge whose both endpoints are green
- force surfaces the OWOX error when the mart is still there
- `pushPreview` reports `alreadyPushed`, counting only marts in the active storage

`packages/web/src/components/PushConfirmDialog.test.tsx`
- the warning block and force button appear only when `alreadyPushed > 0`
- the force button calls `onForcePush`, not `onConfirm`
- `Push` is disabled when both counts are 0

427 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)