### PR TITLE
feat(push): check OWOX before a forced push instead of duplicating marts

### DIFF
--- a/packages/web/src/components/PushConfirmDialog.tsx
+++ b/packages/web/src/components/PushConfirmDialog.tsx
@@ -53,8 +53,8 @@ export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, on
                 {counts.alreadyPushed} {counts.alreadyPushed === 1 ? "mart is" : "marts are"} already created in this project
               </span>
               , so {counts.alreadyPushed === 1 ? "it is" : "they are"} skipped. Deleted {counts.alreadyPushed === 1 ? "it" : "them"} in OWOX?
-              Force-push to create {counts.alreadyPushed === 1 ? "it" : "them"} again — if {counts.alreadyPushed === 1 ? "it is" : "they are"} still
-              there, OWOX will report a duplicate.
+              Force-push to create {counts.alreadyPushed === 1 ? "it" : "them"} again. Anything still present in OWOX is checked first and left
+              alone, so this can't produce duplicates.
             </p>
             <button
               onClick={onForcePush}

--- a/packages/web/src/components/PushToast.test.tsx
+++ b/packages/web/src/components/PushToast.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PushToast } from "./PushToast";
+import type { PushResult } from "../sync/push";
+
+const result = (over: Partial<PushResult> = {}): PushResult => ({
+  created: 0, updated: 0, failed: 0, blocked: 0,
+  relationshipsCreated: 0, relationshipsFailed: 0, errors: [], ...over,
+});
+
+describe("PushToast", () => {
+  it("reports a clean push", () => {
+    render(<PushToast result={result({ created: 8, relationshipsCreated: 8 })} onClose={() => {}} />);
+    expect(screen.getByText("Push complete")).toBeTruthy();
+    expect(screen.getByText(/8 marts created, 8 links created/)).toBeTruthy();
+  });
+
+  it("says nothing was pushed when every mart is still in OWOX", () => {
+    render(<PushToast result={result({ blocked: 8, errors: ['"Orders" still exists in OWOX (DRAFT)'] })} onClose={() => {}} />);
+    expect(screen.queryByText("Push complete")).toBeNull();
+    expect(screen.getByText(/nothing pushed/i)).toBeTruthy();
+    expect(screen.getByText(/8 marts still exist in OWOX/i)).toBeTruthy();
+    expect(screen.getByText(/delete them/i)).toBeTruthy();
+  });
+
+  it("reports both halves when some marts were blocked and others pushed", () => {
+    render(<PushToast result={result({ created: 3, blocked: 5 })} onClose={() => {}} />);
+    expect(screen.getByText(/3 marts created/)).toBeTruthy();
+    expect(screen.getByText(/5 marts still exist in OWOX/i)).toBeTruthy();
+  });
+
+  it("lists the per-mart errors", () => {
+    render(<PushToast result={result({ blocked: 1, errors: ['"Orders" still exists in OWOX (PUBLISHED) — delete it there first'] })} onClose={() => {}} />);
+    expect(screen.getByText(/"Orders" still exists in OWOX \(PUBLISHED\)/)).toBeTruthy();
+  });
+
+  it("still flags real failures", () => {
+    render(<PushToast result={result({ created: 1, failed: 2, errors: ["boom"] })} onClose={() => {}} />);
+    expect(screen.getByText(/push completed with errors/i)).toBeTruthy();
+    expect(screen.getByText(/2 failed/)).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/PushToast.tsx
+++ b/packages/web/src/components/PushToast.tsx
@@ -1,0 +1,56 @@
+import { X } from "lucide-react";
+import type { PushResult } from "../sync/push";
+
+// Push result toast (sticky — dismissed by the user, not on a timer).
+// Three outcomes to tell apart: a clean push, real failures, and a forced push
+// that was held back because the marts are still in OWOX. The last one is not an
+// error the user can fix here — it's an instruction to delete them in OWOX first,
+// so it gets its own headline instead of the success one.
+export function PushToast({ result, onClose }: { result: PushResult; onClose: () => void }) {
+  const blocked = result.blocked ?? 0;
+  const failed = result.failed + result.relationshipsFailed;
+  const pushedNothing = result.created === 0 && result.relationshipsCreated === 0;
+
+  const tone = failed > 0 ? "error" : blocked > 0 ? "warn" : "ok";
+  const title =
+    blocked > 0 && pushedNothing ? "Nothing pushed"
+    : failed > 0 || blocked > 0 ? "Push completed with errors"
+    : "Push complete";
+
+  const parts: string[] = [];
+  if (result.created > 0 || blocked === 0) parts.push(`${result.created} mart${result.created === 1 ? "" : "s"} created`);
+  if (result.relationshipsCreated) parts.push(`${result.relationshipsCreated} link${result.relationshipsCreated === 1 ? "" : "s"} created`);
+  if (failed) parts.push(`${failed} failed`);
+
+  const dot = tone === "error" ? "bg-red-500" : tone === "warn" ? "bg-amber-500" : "bg-emerald-500";
+  const border = tone === "error" ? "border-red-300" : tone === "warn" ? "border-amber-300" : "border-emerald-300";
+
+  return (
+    <div className={`fixed bottom-4 right-4 z-50 w-[420px] max-h-[60vh] overflow-y-auto rounded-xl shadow-2xl border text-[13px] bg-white ${border}`}>
+      <div className="flex items-start gap-2 px-4 py-3 border-b border-slate-100">
+        <span className={`mt-[2px] h-2 w-2 rounded-full flex-shrink-0 ${dot}`} />
+        <div className="flex-1 font-semibold text-slate-800">
+          {title}
+          {parts.length > 0 && (
+            <div className="font-normal text-slate-500 text-[12px] mt-0.5">{parts.join(", ")}</div>
+          )}
+          {blocked > 0 && (
+            <div className="font-normal text-[12px] mt-1 text-[#8a5a00] leading-snug">
+              {blocked} {blocked === 1 ? "mart still exists" : "marts still exist"} in OWOX (draft/active), so{" "}
+              {blocked === 1 ? "it was" : "they were"} not pushed again. Delete {blocked === 1 ? "it" : "them"} in OWOX
+              first — otherwise you end up with duplicates.
+            </div>
+          )}
+        </div>
+        <button onClick={onClose} className="text-slate-400 hover:text-slate-700" title="Dismiss"><X size={16} /></button>
+      </div>
+      {result.errors.length > 0 && (
+        <ul className="px-4 py-2 flex flex-col gap-1.5">
+          {result.errors.map((err, i) => (
+            <li key={i} className={`text-[12px] leading-snug break-words font-mono ${tone === "warn" ? "text-[#8a5a00]" : "text-red-600"}`}>{err}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -53,6 +53,7 @@ import { TemplateApplyDialog } from "../TemplateApplyDialog";
 import { WelcomeDialog } from "../WelcomeDialog";
 import { SignInModal } from "../SignInModal";
 import { PushConfirmDialog } from "../PushConfirmDialog";
+import { PushToast } from "../PushToast";
 import { ClearCanvasDialog } from "../ClearCanvasDialog";
 import { NewModelDialog } from "../NewModelDialog";
 import { pushIntent } from "../../sync/pushGate";
@@ -747,7 +748,7 @@ function CanvasInner() {
       const result = await pushModel(store, undefined, storageType, opts);
       setPushResult(result);
     } catch (e) {
-      setPushResult({ created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [(e as Error).message] });
+      setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [(e as Error).message] });
     } finally {
       setPushing(false);
     }
@@ -925,7 +926,7 @@ function CanvasInner() {
             const list = await loadStorages();
             if (mode === "push") {
               if (list.length === 0) {
-                setPushResult({ created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
+                setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
                 return;
               }
               await runPush(list);
@@ -1082,33 +1083,6 @@ function CanvasInner() {
         </ModelSheet>
         <RightRail active={panel.active} onOpen={handleRailOpen} signedIn={!!account} highlightId={visualRailId} onSave={supabaseEnabled ? handleSave : undefined} saving={saving} saveState={saveState} />
       </div>
-    </div>
-  );
-}
-
-// ── Push result toast (sticky — dismissed by the user, not on a timer) ─────────
-function PushToast({ result, onClose }: { result: PushResult; onClose: () => void }) {
-  const hasFailures = result.failed > 0 || result.relationshipsFailed > 0;
-  const summary = `${result.created} mart${result.created === 1 ? "" : "s"} created`
-    + (result.relationshipsCreated ? `, ${result.relationshipsCreated} link${result.relationshipsCreated === 1 ? "" : "s"} created` : "")
-    + (hasFailures ? `, ${result.failed + result.relationshipsFailed} failed` : "");
-  return (
-    <div className={`fixed bottom-4 right-4 z-50 w-[420px] max-h-[60vh] overflow-y-auto rounded-xl shadow-2xl border text-[13px] ${hasFailures ? "bg-white border-red-300" : "bg-white border-emerald-300"}`}>
-      <div className="flex items-start gap-2 px-4 py-3 border-b border-slate-100">
-        <span className={`mt-[2px] h-2 w-2 rounded-full flex-shrink-0 ${hasFailures ? "bg-red-500" : "bg-emerald-500"}`} />
-        <div className="flex-1 font-semibold text-slate-800">
-          {hasFailures ? "Push completed with errors" : "Push complete"}
-          <div className="font-normal text-slate-500 text-[12px] mt-0.5">{summary}</div>
-        </div>
-        <button onClick={onClose} className="text-slate-400 hover:text-slate-700" title="Dismiss"><X size={16} /></button>
-      </div>
-      {result.errors.length > 0 && (
-        <ul className="px-4 py-2 flex flex-col gap-1.5">
-          {result.errors.map((err, i) => (
-            <li key={i} className="text-[12px] text-red-600 leading-snug break-words font-mono">{err}</li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/packages/web/src/sync/push.ts
+++ b/packages/web/src/sync/push.ts
@@ -9,6 +9,9 @@ export interface PushResult {
   created: number;
   updated: number;
   failed: number;
+  /** Marts a forced push held back because they are still in OWOX. Not a failure
+   *  — nothing broke, we refused to create a duplicate. */
+  blocked: number;
   relationshipsCreated: number;
   relationshipsFailed: number;
   errors: string[];
@@ -50,13 +53,30 @@ export interface PushOptions {
   /** Re-create marts that are already live in the active storage. For the case
    *  where the user deleted them inside OWOX and wants the same model back: the
    *  stored owoxId points at a mart that no longer exists, so skipping it would
-   *  silently push nothing. If a mart is in fact still there, OWOX answers with
-   *  an error, which lands on the node like any other push failure. */
+   *  silently push nothing. Marts that are still in OWOX are held back rather
+   *  than duplicated — see findBlockedMarts. */
   force?: boolean;
 }
 
+/** What a forced push must not touch: marts whose stored owoxId is still listed
+ *  in OWOX. Creating those again would leave the project with two copies and no
+ *  way to tell them apart, so we hold them back and say which status they're in.
+ *  Throws if the listing can't be read — guessing would risk the duplicates this
+ *  check exists to prevent. */
+async function findBlockedMarts(store: ModelStore, api: Api, storageId: string): Promise<Map<string, string | undefined>> {
+  const live = await api<Array<{ id: string; title?: string; status?: string }>>("/api/data-marts");
+  if (!Array.isArray(live)) throw new Error("unexpected data mart listing");
+  const statusById = new Map(live.map(m => [m.id, m.status]));
+  const blocked = new Map<string, string | undefined>();
+  for (const n of store.get().nodes) {
+    if (n.status !== "created" || n.owoxStorageId !== storageId || !n.owoxId) continue;
+    if (statusById.has(n.owoxId)) blocked.set(n.key, statusById.get(n.owoxId));
+  }
+  return blocked;
+}
+
 export async function pushModel(store: ModelStore, api: Api = defaultApi, storageType?: string, opts: PushOptions = {}): Promise<PushResult> {
-  const res: PushResult = { created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [] };
+  const res: PushResult = { created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [] };
 
   const storageId = store.get().storageId;
   if (!storageId) {
@@ -67,7 +87,31 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
     return res;
   }
 
-  // ── 0. Ensure every join-key field exists in its mart's output schema ───────
+  // ── 0. A forced push first asks OWOX what is actually there ─────────────────
+  // The premise of a forced push is "I deleted these in OWOX". Verify it before
+  // creating anything: a mart still listed there would become a duplicate, which
+  // nobody can untangle afterwards. Blocked marts keep their green dot — it is
+  // honest, they really are in OWOX — and are reported instead of pushed.
+  const blockedKeys = new Set<string>();
+  if (opts.force) {
+    let blocked: Map<string, string | undefined>;
+    try {
+      blocked = await findBlockedMarts(store, api, storageId);
+    } catch (e) {
+      res.errors.push(`Could not check which marts still exist in OWOX (${(e as Error).message}) — nothing was pushed.`);
+      return res;
+    }
+    for (const [key, owoxStatus] of blocked) {
+      const title = store.get().nodes.find(n => n.key === key)?.title ?? key;
+      blockedKeys.add(key);
+      res.blocked++;
+      res.errors.push(
+        `"${title}" still exists in OWOX${owoxStatus ? ` (${owoxStatus})` : ""} — delete it there first, otherwise this would create a duplicate.`,
+      );
+    }
+  }
+
+  // ── 1. Ensure every join-key field exists in its mart's output schema ───────
   // Joining on a field that isn't defined is meaningless, so auto-add missing
   // ones before we push schemas. Infer the new field's type from the other side
   // of the join (a key matching an INTEGER PK must not be created as STRING, or
@@ -83,15 +127,16 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
     }
   }
 
-  // ── 1. Create pending marts, then push their output schema ──────────────────
+  // ── 2. Create pending marts, then push their output schema ──────────────────
   // Track marts we skip because they already exist IN THIS STORAGE — a "created"
   // mart whose owoxStorageId points at a different storage (e.g. imported from
   // another project, then signed into this one) is NOT in the active storage, so
   // it must be recreated here rather than silently skipped. A forced push skips
-  // nothing: every mart is created again (and so is every relationship, since
-  // the edge skip below keys off this same set).
+  // only what step 0 found still living in OWOX; everything else is created again
+  // (and so are its relationships, since the edge skip below keys off this set).
   const skippedKeys = new Set<string>();
   for (const n of store.get().nodes) {
+    if (blockedKeys.has(n.key)) { skippedKeys.add(n.key); continue; }
     if (!opts.force && n.status === "created" && n.owoxStorageId === storageId) { skippedKeys.add(n.key); continue; }
     store.updateNode(n.key, { status: "creating", error: null });
     try {
@@ -143,7 +188,7 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
     }
   }
 
-  // ── 2. Create joinable relationships (depends on both marts existing) ───────
+  // ── 3. Create joinable relationships (depends on both marts existing) ───────
   const g = store.get();
   const owoxIdByKey = new Map(g.nodes.map(n => [n.key, n.owoxId]));
   const titleByKey = new Map(g.nodes.map(n => [n.key, n.title]));

--- a/packages/web/test/push.test.ts
+++ b/packages/web/test/push.test.ts
@@ -218,7 +218,17 @@ describe("pushModel", () => {
     expect(res.relationshipsCreated).toBeGreaterThan(0);
   });
 
-  it("force re-creates a mart already live in the active storage (deleted in OWOX)", async () => {
+  // A forced push checks what is actually in OWOX first (GET /api/data-marts),
+  // so it can refuse to duplicate a mart the user did not in fact delete.
+  const forceApi = (liveMarts: Array<{ id: string; title: string; status?: string }>, calls: string[] = []) =>
+    vi.fn(async (path: string, init?: any) => {
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${path}`);
+      if (path === "/api/data-marts" && method === "GET") return liveMarts;
+      return { id: "fresh_id" };
+    });
+
+  it("force re-creates a mart that is gone from OWOX", async () => {
     const s = createModelStore({ storageId: "stor_1" });
     s.set({
       storageId: "stor_1",
@@ -228,15 +238,82 @@ describe("pushModel", () => {
       edges: [],
     });
     const calls: string[] = [];
-    const apiMock = vi.fn(async (path: string) => { calls.push(path); return { id: "fresh_id" }; });
-    const res = await pushModel(s, apiMock as any, undefined, { force: true });
-    expect(calls).toContain("/api/data-marts");
+    const res = await pushModel(s, forceApi([{ id: "other_id", title: "Sessions" }], calls) as any, undefined, { force: true });
+    expect(calls).toContain("POST /api/data-marts");
     expect(res.created).toBe(1);
+    expect(res.blocked).toBe(0);
     expect(s.get().nodes[0].owoxId).toBe("fresh_id"); // the old id pointed at a deleted mart
     expect(s.get().nodes[0].status).toBe("created");
   });
 
-  it("force pushes an existing edge whose both endpoints are live here", async () => {
+  it("force refuses to duplicate a mart that still exists in OWOX, naming its status", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "still_there", owoxStorageId: "stor_1" },
+      ],
+      edges: [],
+    });
+    const calls: string[] = [];
+    const res = await pushModel(s, forceApi([{ id: "still_there", title: "Orders", status: "DRAFT" }], calls) as any, undefined, { force: true });
+    expect(calls).not.toContain("POST /api/data-marts"); // no duplicate created
+    expect(res.created).toBe(0);
+    expect(res.blocked).toBe(1);
+    expect(res.failed).toBe(0); // nothing broke — we deliberately held back
+    expect(res.errors[0]).toMatch(/Orders.*still exists in OWOX.*DRAFT/i);
+    expect(s.get().nodes[0].status).toBe("created"); // it IS in OWOX, so the green dot is honest
+    expect(s.get().nodes[0].owoxId).toBe("still_there");
+  });
+
+  it("force holds back the blocked marts but pushes the deleted ones", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "still_there", owoxStorageId: "stor_1" },
+        { key: "n2", title: "Customers", inputSource: "SQL", schema: [], position: { x: 100, y: 0 }, status: "created", owoxId: "gone", owoxStorageId: "stor_1" },
+      ],
+      edges: [],
+    });
+    const bodies: string[] = [];
+    const apiMock = vi.fn(async (path: string, init?: any) => {
+      if (path === "/api/data-marts" && (init?.method ?? "GET") === "GET") return [{ id: "still_there", title: "Orders", status: "PUBLISHED" }];
+      if (path === "/api/data-marts") bodies.push(String(init?.body));
+      return { id: "fresh_id" };
+    });
+    const res = await pushModel(s, apiMock as any, undefined, { force: true });
+    expect(res.created).toBe(1);
+    expect(res.blocked).toBe(1);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toContain("Customers"); // only the deleted one was recreated
+  });
+
+  it("force does not re-push a relationship between two blocked marts", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [{ name: "customer_id", type: "STRING", pk: false }], position: { x: 0, y: 0 }, status: "created", owoxId: "live_a", owoxStorageId: "stor_1" },
+        { key: "n2", title: "Customers", inputSource: "SQL", schema: [{ name: "id", type: "STRING", pk: true }], position: { x: 100, y: 0 }, status: "created", owoxId: "live_b", owoxStorageId: "stor_1" },
+      ],
+      edges: [
+        { id: "e1", from: "n1", to: "n2", keys: [{ left: "customer_id", right: "id" }], bidirectional: false, existing: true },
+      ],
+    });
+    const calls: string[] = [];
+    const res = await pushModel(
+      s,
+      forceApi([{ id: "live_a", title: "Orders", status: "DRAFT" }, { id: "live_b", title: "Customers", status: "DRAFT" }], calls) as any,
+      undefined,
+      { force: true },
+    );
+    expect(calls.filter(c => c.includes("/relationships"))).toHaveLength(0);
+    expect(res.blocked).toBe(2);
+    expect(res.relationshipsCreated).toBe(0);
+  });
+
+  it("force pushes an existing edge once both endpoints were re-created", async () => {
     const s = createModelStore({ storageId: "stor_1" });
     s.set({
       storageId: "stor_1",
@@ -248,28 +325,40 @@ describe("pushModel", () => {
         { id: "e1", from: "n1", to: "n2", keys: [{ left: "customer_id", right: "id" }], bidirectional: false, existing: true },
       ],
     });
-    const relationshipCalls: string[] = [];
-    const apiMock = vi.fn(async (path: string) => { if (path.includes("/relationships")) relationshipCalls.push(path); return { id: "x" }; });
-    const res = await pushModel(s, apiMock as any, undefined, { force: true });
-    expect(relationshipCalls).toHaveLength(1);
+    const calls: string[] = [];
+    const res = await pushModel(s, forceApi([], calls) as any, undefined, { force: true }); // OWOX is empty — both were deleted
+    expect(calls.filter(c => c.includes("/relationships"))).toHaveLength(1);
     expect(res.relationshipsCreated).toBe(1);
   });
 
-  it("force surfaces an OWOX error when the mart still exists there", async () => {
+  it("force aborts without pushing anything when it cannot check what is in OWOX", async () => {
     const s = createModelStore({ storageId: "stor_1" });
     s.set({
       storageId: "stor_1",
       nodes: [
-        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "still_there", owoxStorageId: "stor_1" },
+        { key: "n1", title: "Orders", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "a", owoxStorageId: "stor_1" },
       ],
       edges: [],
     });
-    const apiMock = vi.fn(async () => { throw new Error("Data mart with this title already exists"); });
+    const calls: string[] = [];
+    const apiMock = vi.fn(async (path: string, init?: any) => {
+      calls.push(`${init?.method ?? "GET"} ${path}`);
+      if (path === "/api/data-marts" && (init?.method ?? "GET") === "GET") throw new Error("HTTP 500");
+      return { id: "fresh_id" };
+    });
     const res = await pushModel(s, apiMock as any, undefined, { force: true });
+    expect(calls).not.toContain("POST /api/data-marts"); // duplicates are unrecoverable, so don't guess
     expect(res.created).toBe(0);
-    expect(res.failed).toBe(1);
-    expect(s.get().nodes[0].status).toBe("error");
-    expect(res.errors[0]).toMatch(/already exists/);
+    expect(res.errors[0]).toMatch(/could not check|HTTP 500/i);
+  });
+
+  it("does not list OWOX marts on a normal push — the skip needs no lookup", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.addNode({ x: 0, y: 0 });
+    const calls: string[] = [];
+    const apiMock = vi.fn(async (path: string, init?: any) => { calls.push(`${init?.method ?? "GET"} ${path}`); return { id: "owox_a" }; });
+    await pushModel(s, apiMock as any);
+    expect(calls).not.toContain("GET /api/data-marts");
   });
 
   it("uses an underscore identifier (not a hyphenated slug) for targetAlias", async () => {


### PR DESCRIPTION
Follow-up to #46.

## Problem

The forced push took the user's word for it. Every green mart was created again, so force-pushing marts that had **not** actually been deleted in OWOX left the project with two copies of each — and the UI said nothing: the toast reported a cheerful `8 marts created`. Duplicated data marts can't be told apart afterwards, so this is a mess the user has to clean up by hand.

The expectation (rightly) was: we know the ids of what we created, so check first and return an error instead.

## Solution

`pushModel` now verifies the premise of a forced push before writing anything. It lists the project's data marts once — `GET /api/data-marts`, already proxied in `packages/server/src/routes/datamarts.ts` — and matches the result against the stored `owoxId`s:

- **Still in OWOX** → held back, not re-created, and reported as
  `"Orders" still exists in OWOX (DRAFT) — delete it there first, otherwise this would create a duplicate.`
  The mart keeps its green dot, which is honest — it really is in OWOX. Its relationships are held back with it (the blocked keys feed the same skip set the edge loop uses), so no duplicate joins either.
- **Gone from OWOX** → created again, as before.
- **Listing unreadable** → the whole push aborts with `Could not check which marts still exist in OWOX (…) — nothing was pushed.` Duplicates are unrecoverable, so doing nothing beats guessing.

`PushResult` gains `blocked` — deliberately held back, kept distinct from `failed` so the summary never claims something broke.

## Toast

`PushToast` moved out of `Canvas.tsx` into its own file — it now has three outcomes to distinguish and deserved direct tests. A forced push that pushed nothing reads:

> **Nothing pushed**
> 8 marts still exist in OWOX (draft/active), so they were not pushed again. Delete them in OWOX first — otherwise you end up with duplicates.

Amber dot and border rather than green, with the per-mart lines below. A partially blocked push reports both halves (`3 marts created` + the blocked note).

The push dialog's warning no longer promises that *OWOX* will report the duplicate — we catch it ourselves now.

## Tests

`packages/web/test/push.test.ts` — force re-creates a mart that is gone; force refuses a mart that is still there and names its status; mixed case pushes only the deleted one; no relationship re-push between two blocked marts; existing edge is pushed once both endpoints were re-created; abort when the check fails; a normal push does no listing at all.

`packages/web/src/components/PushToast.test.tsx` — clean push, nothing-pushed headline, both-halves summary, per-mart error lines, real failures still flagged.

436 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)