### PR TITLE
fix(okf): parse v0.2 frontmatter sequences and labelled schema tables

### DIFF
--- a/packages/okf/src/parse.ts
+++ b/packages/okf/src/parse.ts
@@ -149,37 +149,62 @@ function parseOverview(body: string): { id?: string; status?: string; definition
   return out;
 }
 
-function parseSchema(body: string): import("./types").SchemaField[] {
-  const out: import("./types").SchemaField[] = [];
-  const lines = body.split("\n"); let inSchema = false;
+// Schema-table header labels. Producers pick their own wording and column count
+// — our own export writes `Column | Type | Description`, Google's regenerated
+// v0.2 bundles write `Field Name | Type | Mode | Description` — so every column
+// is located by label instead of assuming a fixed arity.
+const H_NAME = /^(column|column name|field|field name|name)$/i;
+const H_TYPE = /^(type|data type)$/i;
+const H_DESC = /^(description|desc|notes?|comment|comments)$/i;
+const H_PK = /^(pk|primary key)$/i;
+const H_ALIAS = /^alias$/i;
+
+// Cell text without the code ticks or bold/italic markers a generator may wrap
+// it in (`**gross_amount**`, `*event_params.key*`). Underscores are left alone —
+// they are legitimate in field names (`events_`, `_partitiontime`).
+function cellText(s: string): string {
+  return s.replace(/`/g, "").trim().replace(/^\*{1,3}/, "").replace(/\*{1,3}$/, "").trim();
+}
+
+function parseSchema(body: string): SchemaField[] {
+  const out: SchemaField[] = [];
+  const lines = body.split("\n"); let inSchema = false; let headerSeen = false;
   // Column positions come from the header row, so the canonical
-  // `| Column | Type | Description |` form, the optional-Alias form, and the
-  // legacy `| Column | Type | PK | Alias | Description |` form all parse
-  // without guessing at the arity. Description falls back to index 2 for
+  // `| Column | Type | Description |` form, the optional-Alias form, the legacy
+  // `| Column | Type | PK | Alias | Description |` form and Google's
+  // `| Field Name | Type | Mode | Description |` all parse without guessing at
+  // the arity. Name/type/description fall back to the first three columns for
   // tables written without a header.
-  let idxPk = -1, idxAlias = -1, idxDesc = 2;
+  let idxName = 0, idxType = 1, idxDesc = 2, idxPk = -1, idxAlias = -1;
   for (const ln of lines) {
     if (/^##?\s+Schema/i.test(ln)) { inSchema = true; continue; }
     if (!inSchema) continue;
     if (/^##?\s+/.test(ln)) break;
     if (!/^\s*\|/.test(ln)) continue;
-    const cells = ln.split("|").slice(1, -1).map(c => c.trim());
+    const cells = ln.split("|").slice(1, -1).map(cellText);
     if (cells.length < 2) continue;
-    const name = cells[0].replace(/`/g, "").trim();
-    if (!name || /^column$/i.test(name)) { // header row
-      idxPk = cells.findIndex(c => /^pk$/i.test(c));
-      idxAlias = cells.findIndex(c => /^alias$/i.test(c));
-      const d = cells.findIndex(c => /^description$/i.test(c));
-      idxDesc = d >= 0 ? d : (idxPk === 2 || idxAlias === 2 ? -1 : 2);
+    if (/^:?-+:?$/.test(cells[0])) continue; // separator
+    const labels = [H_NAME, H_TYPE, H_DESC, H_PK, H_ALIAS].map(re => cells.findIndex(c => re.test(c)));
+    const [hName, hType, hDesc, hPk, hAlias] = labels;
+    // Two recognized labels mark a header row. One is not enough — a real field
+    // can be called `name` or `type`, and by the time such a row is reached the
+    // table's own header has already been consumed.
+    if (!headerSeen && (!cells[0] || labels.filter(i => i >= 0).length >= 2)) {
+      headerSeen = true;
+      if (hName >= 0) idxName = hName;
+      if (hType >= 0) idxType = hType;
+      idxPk = hPk; idxAlias = hAlias;
+      idxDesc = hDesc >= 0 ? hDesc : (hPk === 2 || hAlias === 2 ? -1 : 2);
       continue;
     }
-    if (/^:?-+:?$/.test(name)) continue; // separator
-    const type = (cells[1] || "STRING").replace(/`/g, "").trim() || "STRING";
-    const field: import("./types").SchemaField = { name, type, pk: false };
-    if (idxPk >= 0) field.pk = /^(✓|x|X)$/.test((cells[idxPk] || "").trim());
-    let desc = (idxDesc >= 0 ? cells[idxDesc] || "" : "").trim();
+    const at = (i: number) => (i >= 0 ? cells[i] ?? "" : "");
+    const name = at(idxName);
+    if (!name) continue;
+    const field: SchemaField = { name, type: at(idxType) || "STRING", pk: false };
+    if (idxPk >= 0) field.pk = /^(✓|x|X)$/.test(at(idxPk));
+    let desc = at(idxDesc);
     if (/^PK\.\s*/.test(desc)) { field.pk = true; desc = desc.replace(/^PK\.\s*/, "").trim(); }
-    const alias = (idxAlias >= 0 ? cells[idxAlias] || "" : "").replace(/`/g, "").trim();
+    const alias = at(idxAlias);
     if (alias) field.alias = alias;
     if (desc) field.description = desc;
     out.push(field);

--- a/packages/okf/src/slug.ts
+++ b/packages/okf/src/slug.ts
@@ -30,17 +30,104 @@ export function parseFrontmatter(text: string): { data: Record<string, any>; bod
   if (!m) return { data: {}, body: text };
   return { data: parseYaml(m[1]), body: m[2] };
 }
+// A frame owns one container. `indent` is the column of the key that introduced
+// it (-1 for the root, the dash column for a sequence), so a frame's children
+// always sit at a deeper indent — except a sequence, whose dashes YAML allows at
+// the same column as their key. `pending` is a key whose value shape is not yet
+// known: the next line decides between a mapping and a sequence.
+type Frame =
+  | { kind: "map"; indent: number; obj: Record<string, any> }
+  | { kind: "seq"; indent: number; arr: any[] }
+  | { kind: "pending"; indent: number; parent: Record<string, any>; key: string };
+
+// A pending frame that never got children keeps the pre-sequence behaviour of
+// resolving to an empty mapping (`tags:` with nothing under it => {}).
+function closeFrame(f: Frame): void {
+  if (f.kind === "pending") f.parent[f.key] = {};
+}
+
 function parseYaml(src: string): Record<string, any> {
-  const root: Record<string, any> = {}; const stack: { indent: number; obj: any }[] = [{ indent: -1, obj: root }];
+  const root: Record<string, any> = {};
+  const stack: Frame[] = [{ kind: "map", indent: -1, obj: root }];
   const lines = src.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
     if (!raw.trim()) continue;
     const indent = raw.match(/^ */)![0].length;
-    const line = raw.trim(); const ci = line.indexOf(":"); if (ci < 0) continue;
-    const key = line.slice(0, ci).trim(); const rest = line.slice(ci + 1).trim();
-    while (stack.length && indent <= stack[stack.length - 1].indent) stack.pop();
-    const parent = stack[stack.length - 1].obj;
+    const line = raw.trim();
+
+    // `- item` — a sequence entry. OKF v0.2 puts lists of mappings in the
+    // frontmatter (`sources`, `verified`, `parameters`); without this branch
+    // their nested keys leaked onto the root and clobbered same-named top-level
+    // keys, so the last `sources[].title` won over the document's own title.
+    const item = line.match(/^-(?:\s+(.*))?$/);
+    if (item) {
+      // Unwind to the frame that owns this sequence: either the sequence itself
+      // (a sibling entry, dashes at the same column) or the key that introduces
+      // it (at the same column or shallower).
+      while (stack.length > 1) {
+        const top = stack[stack.length - 1];
+        if (top.kind === "seq" && top.indent === indent) break;
+        if (top.kind === "pending" && top.indent <= indent) break;
+        closeFrame(stack.pop()!);
+      }
+      const top = stack[stack.length - 1];
+      let arr: any[];
+      if (top.kind === "pending") {
+        arr = [];
+        top.parent[top.key] = arr;
+        stack[stack.length - 1] = { kind: "seq", indent, arr };
+      } else if (top.kind === "seq") {
+        arr = top.arr;
+      } else continue;                       // a sequence with no owning key
+      const content = item[1] ?? "";
+      if (content === "") {                  // `-` alone: mapping starts next line
+        const obj: Record<string, any> = {};
+        arr.push(obj);
+        stack.push({ kind: "map", indent, obj });
+        continue;
+      }
+      const ci = content.indexOf(":");
+      // A scalar or an inline flow collection is the whole entry.
+      if (ci < 0 || /^[[{"']/.test(content)) { arr.push(parseValue(content)); continue; }
+      // `- key: value` opens a mapping entry whose first key lives on this line.
+      const obj: Record<string, any> = {};
+      arr.push(obj);
+      stack.push({ kind: "map", indent, obj });
+      i = assign(stack, obj, indent + (line.length - content.length), content, lines, i);
+      continue;
+    }
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) closeFrame(stack.pop()!);
+    const top = stack[stack.length - 1];
+    // A mapping key directly under a sequence (no dash) is malformed; skip it
+    // rather than writing string keys onto an array.
+    if (top.kind === "seq") continue;
+    const parent = top.kind === "pending" ? materialize(stack) : top.obj;
+    i = assign(stack, parent, indent, line, lines, i);
+  }
+  while (stack.length > 1) closeFrame(stack.pop()!);
+  return root;
+}
+
+// Turn the pending frame on top of the stack into a mapping and return it.
+function materialize(stack: Frame[]): Record<string, any> {
+  const f = stack[stack.length - 1] as Extract<Frame, { kind: "pending" }>;
+  const obj: Record<string, any> = {};
+  f.parent[f.key] = obj;
+  stack[stack.length - 1] = { kind: "map", indent: f.indent, obj };
+  return obj;
+}
+
+// Assign one `key: value` line into `parent`. Block scalars consume following
+// lines, so the index of the last line used is returned.
+function assign(
+  stack: Frame[], parent: Record<string, any>, indent: number,
+  line: string, lines: string[], i: number,
+): number {
+  const ci = line.indexOf(":"); if (ci < 0) return i;
+  const key = line.slice(0, ci).trim(); const rest = line.slice(ci + 1).trim();
+  {
     const blockMatch = rest.match(/^([|>])(?:[+-])?$/);
     if (blockMatch) {
       const [, style] = blockMatch;
@@ -62,18 +149,24 @@ function parseYaml(src: string): Record<string, any> {
       // never need a trailing newline, so trailing whitespace is always trimmed.
       const joined = (style === "|" ? stripped.join("\n") : stripped.join(" ")).replace(/\s+$/, "");
       parent[key] = joined;
-      i = j - 1;
-      continue;
+      return j - 1;
     }
-    if (rest === "") { const obj: Record<string, any> = {}; parent[key] = obj; stack.push({ indent, obj }); }
-    else parent[key] = parseValue(rest);
   }
-  return root;
+  // An empty value defers the shape decision to the next line (mapping vs list).
+  if (rest === "") stack.push({ kind: "pending", indent, parent, key });
+  else parent[key] = parseValue(rest);
+  return i;
 }
 function parseValue(s: string): unknown {
   if (s.startsWith("[")) return s.slice(1, -1).split(",").map(x => parseValue(x.trim())).filter(x => x !== "");
-  if (s.startsWith("{")) { const o: Record<string, number> = {};
-    s.slice(1, -1).split(",").forEach(p => { const [k, v] = p.split(":").map(x => x.trim()); if (k) o[k] = Number(v); }); return o; }
+  // Inline flow mapping. Split on the FIRST colon so actor values keep their own
+  // (`by: human:kliu@acme`); values are parsed, not coerced, so `{ x: 1, y: 2 }`
+  // still yields numbers while `{ by: agent/v1 }` stays a string.
+  if (s.startsWith("{")) { const o: Record<string, unknown> = {};
+    s.slice(1, -1).split(",").forEach(p => {
+      const ci = p.indexOf(":"); if (ci < 0) return;
+      const k = p.slice(0, ci).trim(); if (k) o[k] = parseValue(p.slice(ci + 1).trim());
+    }); return o; }
   if (s.startsWith('"')) return s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
   if (/^-?\d+(\.\d+)?$/.test(s)) return Number(s);
   if (s === "true" || s === "false") return s === "true";

--- a/packages/okf/test/fixtures/google/acme_retail/tables/index.md
+++ b/packages/okf/test/fixtures/google/acme_retail/tables/index.md
@@ -1,0 +1,3 @@
+# BigQuery Table
+
+* [Customer Orders](orders.md) - One row per completed customer order across web, mobile, and marketplace channels.

--- a/packages/okf/test/fixtures/google/acme_retail/tables/orders.md
+++ b/packages/okf/test/fixtures/google/acme_retail/tables/orders.md
@@ -1,0 +1,49 @@
+---
+type: BigQuery Table
+title: Customer Orders
+description: One row per completed customer order across web, mobile, and marketplace channels. The grain is the order, not the line item; per-line product detail lives in `order_lines`.
+resource: https://console.cloud.google.com/bigquery?p=acme&d=sales&t=orders
+tags: [sales, orders, revenue]
+generated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-30T14:00:00Z }
+verified:
+  - { by: human:kliu@acme, at: 2026-07-01T16:00:00Z }
+status: stable
+stale_after: 2026-12-31
+sources:
+  - id: warehouse-schema
+    resource: https://wiki.acme.internal/data/warehouse/schemas/sales
+    title: Acme Retail warehouse schema — sales dataset
+    author: team:data-platform
+    usage_count: 1240
+    last_modified: 2026-06-15
+  - id: revenue-policy
+    resource: policies/revenue-recognition.md
+    title: Revenue Recognition Policy (FY2026)
+    author: human:jsmith@acme
+    last_modified: 2026-06-15
+usage_window: { from: 2026-04-01, to: 2026-06-30 }
+---
+
+# Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `order_id` | STRING | Globally unique order id. Generated at order creation. [^warehouse-schema] |
+| `customer_id` | STRING | FK into `customers`. Never null for completed orders. [^warehouse-schema] |
+| `order_ts` | TIMESTAMP | Order placement time in UTC. This is the timestamp used for fiscal-year assignment. [^revenue-policy] |
+| `order_status` | STRING | One of `pending`, `paid`, `shipped`, `delivered`, `cancelled`, `refunded`. Revenue is recognized only when `order_status = 'delivered'` and the 30-day return window has closed. [^revenue-policy] |
+| `gross_amount` | NUMERIC(18,4) | Pre-discount subtotal, in `currency`. Excludes tax and shipping. [^warehouse-schema] |
+| `discount_amount` | NUMERIC(18,4) | Total discounts applied (promo codes, loyalty credits, price adjustments). [^warehouse-schema] |
+| `net_amount` | NUMERIC(18,4) | `gross_amount - discount_amount`. This is the recognized-revenue amount per policy. [^revenue-policy] |
+| `shipping_amount` | NUMERIC(18,4) | Carrier charge billed to the customer. Excluded from revenue (pass-through liability). [^revenue-policy] |
+| `tax_amount` | NUMERIC(18,4) | Sales tax collected. Excluded from revenue (pass-through liability). [^revenue-policy] |
+| `currency` | STRING | ISO 4217 currency code. Non-USD orders convert via `finance.fx_daily_rates` on `order_ts` date. [^revenue-policy] |
+| `channel` | STRING | Order origin: `web`, `mobile`, `marketplace`. Marketplace orders (Amazon, eBay) are net-settled and recognized on marketplace payout, not on `order_status = 'delivered'`. |
+
+# Notes for consumers
+
+- The grain assumption trips up new analysts: `SUM(net_amount) GROUP BY order_id` is a no-op because there is exactly one row per order. For per-SKU revenue, join `order_lines`.
+- The `refunded` status is terminal in this table; the refund event itself lives in `finance.refunds`, keyed on `order_id`.
+
+[^warehouse-schema]: Acme Retail warehouse schema — sales dataset
+[^revenue-policy]: Revenue Recognition Policy (FY2026)

--- a/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/blocks.md
+++ b/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/blocks.md
@@ -1,0 +1,111 @@
+---
+type: BigQuery Table
+resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datasets/crypto_bitcoin/tables/blocks
+title: Bitcoin Blocks Table
+description: All blocks from the Bitcoin blockchain, including block headers, transaction
+  counts, sizes, and timestamps.
+tags:
+- bitcoin
+- blockchain
+- crypto
+generated:
+  by: reference_agent/gemini-3.5-flash
+  at: '2026-07-10T23:16:06+00:00'
+sources:
+- resource: https://github.com/blockchain-etl/bitcoin-etl
+  title: Bitcoin ETL Export Tool
+  id: bitcoin-etl
+- id: bip-141
+  resource: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
+  title: BIP-141 Segregated Witness (Consensus layer)
+---
+
+The `blocks` table contains structured records for every block in the Bitcoin blockchain [^bitcoin-etl]. Each row in this table represents a single block, captured with detailed block header attributes such as hash, size, transaction count, nonce, difficulty bits, and the Merkle root of all transactions contained within that block.
+
+The dataset is continually exported from live nodes and represents a complete historical index of Bitcoin blocks starting from the genesis block in January 2009. The table is partitioned by month using the `timestamp_month` column to optimize query performance and lower data scanning costs when filtering blocks by date.
+
+The table can be joined with [transactions](transactions.md) to drill down into individual payments or to aggregate block-level statistics like total transaction fees, transaction densities, and witness data weights.
+
+# Schema
+
+| Field Name | Type | Mode | Description |
+| :--- | :--- | :--- | :--- |
+| **hash** | STRING | REQUIRED | Unique block hash that identifies the block. |
+| **size** | INTEGER | NULLABLE | Total size of the block data in bytes. |
+| **stripped_size** | INTEGER | NULLABLE | The size of block data in bytes excluding witness data. |
+| **weight** | INTEGER | NULLABLE | Three times the base size plus the total size as defined in BIP-141 [^bip-141]. |
+| **number** | INTEGER | REQUIRED | The sequential height of the block. |
+| **version** | INTEGER | NULLABLE | Protocol version specified in the block header. |
+| **merkle_root** | STRING | NULLABLE | The root node of a Merkle tree, where leaves are transaction hashes. |
+| **timestamp** | TIMESTAMP | REQUIRED | Block creation timestamp specified in the block header. |
+| **timestamp_month** | DATE | REQUIRED | Month of the block creation timestamp (used as the partitioning key). |
+| **nonce** | STRING | NULLABLE | Difficulty solution specified in the block header. |
+| **bits** | STRING | NULLABLE | Difficulty threshold specified in the block header. |
+| **coinbase_param** | STRING | NULLABLE | Data specified in the coinbase transaction of this block. |
+| **transaction_count** | INTEGER | NULLABLE | Number of transactions included in this block. |
+
+# Common query patterns
+
+### 1. Daily block counts and average transactions per block
+Find out how many blocks are mined each day and the average number of transactions per block for a specific month.
+
+```sql
+SELECT
+  DATE(timestamp) AS block_date,
+  COUNT(1) AS blocks_mined,
+  AVG(transaction_count) AS avg_transactions_per_block,
+  SUM(transaction_count) AS total_transactions
+FROM
+  `bigquery-public-data.crypto_bitcoin.blocks`
+WHERE
+  timestamp_month = '2023-10-01'
+GROUP BY
+  block_date
+ORDER BY
+  block_date ASC;
+```
+
+### 2. Retrieve details for a specific block height
+Lookup a single block's metadata and structure using its height number.
+
+```sql
+SELECT
+  number,
+  hash,
+  timestamp,
+  size,
+  transaction_count,
+  version,
+  coinbase_param
+FROM
+  `bigquery-public-data.crypto_bitcoin.blocks`
+WHERE
+  number = 800000;
+```
+
+### 3. Calculate monthly average block size and weight
+Analyze the adoption and impact of SegWit over time by analyzing the trends in block size, stripped size, and SegWit weight [^bip-141].
+
+```sql
+SELECT
+  timestamp_month,
+  COUNT(1) AS blocks_mined,
+  AVG(size) AS avg_block_size_bytes,
+  AVG(stripped_size) AS avg_stripped_size_bytes,
+  AVG(weight) AS avg_weight
+FROM
+  `bigquery-public-data.crypto_bitcoin.blocks`
+WHERE
+  timestamp_month >= '2020-01-01'
+GROUP BY
+  timestamp_month
+ORDER BY
+  timestamp_month DESC;
+```
+
+# Joins
+
+- [transactions](../references/joins/blocks___transactions.md) — Connects blocks to all included transactions to trace block validation times, miner fee revenue, or transaction densities.
+
+[^bitcoin-etl]: https://github.com/blockchain-etl/bitcoin-etl
+[^bip-141]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki

--- a/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/index.md
+++ b/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/index.md
@@ -1,0 +1,6 @@
+# BigQuery Table
+
+* [Bitcoin Blocks Table](blocks.md) - All blocks from the Bitcoin blockchain, including block headers, transaction counts, sizes, and timestamps.
+* [Bitcoin Outputs Table](outputs.md) - Outputs from all Bitcoin transactions, including script details and values in Satoshis.
+* [Bitcoin Transaction Inputs](inputs.md) - Bitcoin transaction inputs detailing UTXOs spent.
+* [Bitcoin Transactions Table](transactions.md) - All Bitcoin transactions containing inputs, outputs, block metadata, and fee structures.

--- a/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/inputs.md
+++ b/packages/okf/test/fixtures/google/crypto_bitcoin_v02/tables/inputs.md
@@ -1,0 +1,102 @@
+---
+type: BigQuery Table
+resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datasets/crypto_bitcoin/tables/inputs
+title: Bitcoin Transaction Inputs
+description: Bitcoin transaction inputs detailing UTXOs spent.
+tags:
+- bitcoin
+- crypto
+- blockchain
+- utxo
+- inputs
+generated:
+  by: reference_agent/gemini-3.5-flash
+  at: '2026-07-10T23:16:22+00:00'
+sources:
+- resource: https://github.com/blockchain-etl/bitcoin-etl
+  title: Bitcoin ETL GitHub Repository
+  id: bitcoin-etl
+---
+
+The `inputs` table contains details of all transaction inputs (UTXOs spent) on the Bitcoin blockchain. Each row represents a single input that was consumed to fund a transaction[^bitcoin-etl]. Because Bitcoin uses an Unspent Transaction Output (UTXO) model, every transaction consumes existing outputs (which become "inputs" in the new transaction) and creates new outputs[^bitcoin-etl].
+
+This table is particularly useful for tracking the flow of funds, analyzing spending behavior, and tracing transaction lineage. By linking the `spent_transaction_hash` and `spent_output_index` of an input back to the [outputs](outputs.md) table, analysts can fully reconstruct the transaction graph. 
+
+Data is exported from the blockchain using the open-source [bitcoin-etl](https://github.com/blockchain-etl/bitcoin-etl) tool[^bitcoin-etl] and is housed in the [crypto_bitcoin](../datasets/crypto_bitcoin.md) dataset.
+
+# Schema
+
+| Field Name | Type | Mode | Description |
+| :--- | :--- | :--- | :--- |
+| **transaction_hash** | STRING | NULLABLE | Hash of the transaction containing this input |
+| **block_hash** | STRING | NULLABLE | Hash of the block containing this transaction |
+| **block_number** | INTEGER | NULLABLE | Height of the block containing this transaction |
+| **block_timestamp** | TIMESTAMP | NULLABLE | Timestamp of the block containing this transaction |
+| **index** | INTEGER | NULLABLE | 0-based index of this input within the transaction |
+| **spent_transaction_hash** | STRING | NULLABLE | Hash of the transaction containing the output spent by this input |
+| **spent_output_index** | INTEGER | NULLABLE | Index of the output spent by this input in the original transaction |
+| **script_asm** | STRING | NULLABLE | Symbolic representation of the input's script (scriptSig) |
+| **script_hex** | STRING | NULLABLE | Hexadecimal representation of the input's script (scriptSig) |
+| **sequence** | INTEGER | NULLABLE | Transaction input sequence number |
+| **required_signatures** | INTEGER | NULLABLE | Number of signatures required to spend (if applicable) |
+| **type** | STRING | NULLABLE | Type of script (e.g., `witness_v1_taproot`, `pubkeyhash`) |
+| **addresses** | STRING | REPEATED | List of addresses associated with this input |
+| **value** | NUMERIC | NULLABLE | Value of the spent output in Satoshis |
+
+# Common query patterns
+
+### 1. Identify the largest transaction inputs in a given period
+This query retrieves the largest inputs consumed on a specific day, demonstrating how to find massive UTXO consolidations or large-value transfers.
+
+```sql
+SELECT 
+  block_timestamp,
+  transaction_hash,
+  value / 100000000 AS value_btc,
+  addresses
+FROM `bigquery-public-data.crypto_bitcoin.inputs`
+WHERE block_timestamp >= '2024-04-17 00:00:00 UTC'
+  AND block_timestamp < '2024-04-18 00:00:00 UTC'
+ORDER BY value DESC
+LIMIT 10;
+```
+
+### 2. Track input types over time
+Analyze the adoption of modern Bitcoin script types (like Taproot) by counting inputs grouped by their transaction script type.
+
+```sql
+SELECT 
+  DATE(block_timestamp) AS block_date,
+  type,
+  COUNT(1) AS input_count,
+  SUM(value) / 100000000 AS total_value_btc
+FROM `bigquery-public-data.crypto_bitcoin.inputs`
+WHERE block_timestamp >= '2024-01-01 00:00:00 UTC'
+GROUP BY block_date, type
+ORDER BY block_date DESC, input_count DESC;
+```
+
+### 3. Trace provenance by joining inputs and outputs
+To find where funds spent in a transaction came from, you can join the inputs table to the outputs table using the spent transaction keys.
+
+```sql
+SELECT 
+  inp.transaction_hash AS spending_tx,
+  inp.block_timestamp AS spend_time,
+  out.transaction_hash AS source_tx,
+  out.block_timestamp AS source_time,
+  inp.value / 100000000 AS value_btc
+FROM `bigquery-public-data.crypto_bitcoin.inputs` AS inp
+JOIN `bigquery-public-data.crypto_bitcoin.outputs` AS out
+  ON inp.spent_transaction_hash = out.transaction_hash
+  AND inp.spent_output_index = out.index
+WHERE inp.block_timestamp >= '2024-04-17 00:00:00 UTC'
+  AND inp.block_timestamp < '2024-04-17 01:00:00 UTC'
+LIMIT 10;
+```
+
+# Joins
+
+- [transactions](../references/joins/inputs___transactions.md) — Connects this spent input to the parent transaction record which spent it.
+
+[^bitcoin-etl]: https://github.com/blockchain-etl/bitcoin-etl

--- a/packages/okf/test/parse-okf-v02.test.ts
+++ b/packages/okf/test/parse-okf-v02.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { parseBundle } from "../src/parse";
+import { loadBundle } from "./fixtures-loader";
+
+// Fixtures are verbatim copies of Google's OKF v0.2 output (July 2026):
+// `crypto_bitcoin_v02/tables` from the regenerated public bundle, and
+// `acme_retail/tables/orders.md` from the spec's reference bundle.
+
+describe("OKF v0.2 — frontmatter with sequences", () => {
+  it("keeps the document's own title when sources[] carries titles of its own", () => {
+    const g = parseBundle(loadBundle("crypto_bitcoin_v02"));
+    const titles = Object.fromEntries(g.nodes.map(n => [n.key, n.title]));
+    expect(titles).toEqual({
+      blocks: "Bitcoin Blocks Table",
+      inputs: "Bitcoin Transaction Inputs",
+    });
+  });
+
+  it("keeps the document's own description alongside sources[] and generated", () => {
+    const g = parseBundle(loadBundle("acme_retail"));
+    const orders = g.nodes.find(n => n.key === "orders")!;
+    expect(orders.title).toBe("Customer Orders");
+    expect(orders.description).toMatch(/^One row per completed customer order/);
+  });
+});
+
+describe("OKF v0.2 — schema tables", () => {
+  it("reads Field Name | Type | Mode | Description without a phantom header field", () => {
+    const g = parseBundle(loadBundle("crypto_bitcoin_v02"));
+    const blocks = g.nodes.find(n => n.key === "blocks")!;
+    expect(blocks.schema.map(f => f.name)).not.toContain("Field Name");
+    const hash = blocks.schema.find(f => f.name === "hash");
+    expect(hash).toBeDefined();
+    expect(hash!.type).toBe("STRING");
+    // The Mode column must not be mistaken for the description.
+    expect(hash!.description).toBe("Unique block hash that identifies the block.");
+    expect(blocks.schema.some(f => f.description === "REQUIRED" || f.description === "NULLABLE")).toBe(false);
+  });
+
+  it("strips the bold markers generators wrap field names in", () => {
+    const g = parseBundle(loadBundle("crypto_bitcoin_v02"));
+    for (const n of g.nodes) {
+      expect(n.schema.every(f => !f.name.includes("*"))).toBe(true);
+      expect(n.schema.every(f => !f.name.includes("`"))).toBe(true);
+    }
+  });
+
+  it("still reads the canonical Column | Type | Description form", () => {
+    const g = parseBundle(loadBundle("acme_retail"));
+    const orders = g.nodes.find(n => n.key === "orders")!;
+    const byName = Object.fromEntries(orders.schema.map(f => [f.name, f]));
+    expect(orders.schema).toHaveLength(11);
+    expect(byName.order_id.type).toBe("STRING");
+    expect(byName.order_ts.type).toBe("TIMESTAMP");
+    expect(byName.order_id.description).toMatch(/^Globally unique order id/);
+  });
+});

--- a/packages/okf/test/slug.test.ts
+++ b/packages/okf/test/slug.test.ts
@@ -112,3 +112,72 @@ describe("block scalar serialization", () => {
     expect(text).toBe('description: "single line"');
   });
 });
+
+// OKF v0.2 puts sequences of mappings in the frontmatter (`sources`, `verified`,
+// `parameters`). Their nested keys must stay inside the sequence — before this
+// they leaked onto the root and clobbered same-named top-level keys.
+describe("sequences", () => {
+  const parse = (src: string) => parseFrontmatter("---\n" + src + "\n---\nbody").data;
+
+  it("keeps a sequence of mappings out of the root, dashes at the key's column", () => {
+    const data = parse([
+      "title: Bitcoin Blocks Table",
+      "sources:",
+      "- resource: https://github.com/blockchain-etl/bitcoin-etl",
+      "  title: Bitcoin ETL Export Tool",
+      "  id: bitcoin-etl",
+      "- resource: https://github.com/bitcoin/bips",
+      "  title: BIP-141 Segregated Witness",
+      "  id: bip-141",
+      "type: BigQuery Table",
+    ].join("\n"));
+    expect(data.title).toBe("Bitcoin Blocks Table");
+    expect(data.type).toBe("BigQuery Table");
+    expect(data.sources).toHaveLength(2);
+    expect(data.sources[1]).toEqual({
+      resource: "https://github.com/bitcoin/bips",
+      title: "BIP-141 Segregated Witness",
+      id: "bip-141",
+    });
+  });
+
+  it("handles indented dashes and inline flow mappings", () => {
+    const data = parse([
+      "title: Revenue",
+      "verified:",
+      "  - { by: human:jsmith@acme, at: 2026-07-01T09:00:00Z }",
+      "parameters:",
+      "  - { name: year, type: integer, required: true }",
+      "status: stable",
+    ].join("\n"));
+    expect(data.title).toBe("Revenue");
+    expect(data.status).toBe("stable");
+    expect(data.verified).toEqual([{ by: "human:jsmith@acme", at: "2026-07-01T09:00:00Z" }]);
+    expect(data.parameters).toEqual([{ name: "year", type: "integer", required: true }]);
+  });
+
+  it("reads a block-style scalar list", () => {
+    const data = parse(["tags:", "- bitcoin", "- blockchain", "type: BigQuery Table"].join("\n"));
+    expect(data.tags).toEqual(["bitcoin", "blockchain"]);
+    expect(data.type).toBe("BigQuery Table");
+  });
+
+  it("keeps a mapping nested inside a sequence entry", () => {
+    const data = parse([
+      "runtime: bigquery",
+      "steps:",
+      "- executor:",
+      "    resource: skills/run-on-bq.md",
+      "  label: run",
+      "attester:",
+      "  resource: attesters/sql_equality.py",
+    ].join("\n"));
+    expect(data.runtime).toBe("bigquery");
+    expect(data.steps).toEqual([{ executor: { resource: "skills/run-on-bq.md" }, label: "run" }]);
+    expect(data.attester).toEqual({ resource: "attesters/sql_equality.py" });
+  });
+
+  it("leaves a key with no children as an empty mapping (unchanged regression)", () => {
+    expect(parse(["description:", "type: X"].join("\n"))).toEqual({ description: {}, type: "X" });
+  });
+});


### PR DESCRIPTION
## Why

Google shipped **OKF v0.2** on 2026-07-24 ([spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)) and regenerated every public bundle. The spec's own breaking changes (`timestamp` → `generated`, `# Citations` → `sources`) touch fields we never read, but two of our import assumptions no longer hold, and both are visible on `crypto_bitcoin/tables` today.

### 1. Frontmatter sequences clobbered top-level keys

`sources`, `verified` and `parameters` are sequences of mappings — a shape the hand-rolled YAML parser could not represent. A `- key: value` line sitting at the sequence's own column popped its parent frame, so nested keys landed on the **root**:

```yaml
title: Bitcoin Blocks Table
sources:
- resource: https://github.com/bitcoin/bips/…
  title: BIP-141 Segregated Witness (Consensus layer)   # ← overwrote the root title
```

The last `sources[].title` in a document won. Importing `crypto_bitcoin/tables` produced:

| key | title before | title after |
|---|---|---|
| `blocks` | BIP-141 Segregated Witness (Consensus layer) | Bitcoin Blocks Table |
| `inputs` | Bitcoin ETL GitHub Repository | Bitcoin Transaction Inputs |
| `outputs` | Bitcoin ETL Export Tool | Bitcoin Outputs Table |
| `transactions` | 'Bitcoin in BigQuery: blockchain analytics on public data' | Bitcoin Transactions Table |

`type` was exposed to the same clobbering, which would silently reclassify a document or drop it from the graph.

### 2. Schema-table headers were matched by literal text

Header detection keyed on the cell `Column`, so Google's `| Field Name | Type | Mode | Description |` was not recognized as a header at all. It became a field named `Field Name`, and Description fell back to index 2 — the **Mode** column:

```
before:  Field Name:Type("Mode") | **hash**:STRING("REQUIRED") | **size**:INTEGER("NULLABLE")
after:   hash:STRING("Unique block hash that identifies the block.") | size:INTEGER("Total size…")
```

## What changed

**`slug.ts` — `parseYaml`** now tracks frames as `map` / `seq` / `pending`, materializing a pending key as a sequence or a mapping based on its first child line. Dashes are accepted both at the key's column and indented. Behaviour preserved: a key with no children still resolves to an empty mapping. Inline flow mappings split on the first colon (so `{ by: human:jsmith@acme }` keeps its value) and parse rather than coerce entries, so `position: { x: 1, y: 2 }` stays numeric.

**`parse.ts` — `parseSchema`** locates every column by label (`name` / `type` / `description` / `pk` / `alias`), requiring two matches before treating a row as a header — one is not enough, since a real field can be called `name` or `type`. Extra columns are ignored, so `Mode` no longer displaces Description. Cell text is stripped of the bold/italic markers generators wrap names in (`**hash**`, `*event_params.key*`); underscores are left alone because they are legitimate in field names (`events_`, `_partitiontime`). Tables with no header keep the previous first-three-columns behaviour.

## Verification

- `pnpm -r test` — 533 passing (okf 64, server 36, web 433). All 54 pre-existing okf tests unchanged.
- `pnpm build` clean.
- New fixtures are **verbatim** copies of live v0.2 output: `crypto_bitcoin_v02/tables` (4-column table, bold names, `sources[]` with competing titles) and `acme_retail/tables/orders.md` (spec reference bundle: `generated` / `verified` / `status` / `stale_after` / `sources`).
- New tests: 5 in `parse-okf-v02.test.ts`, 5 covering sequences in `slug.test.ts`.

## Deliberately out of scope

Left for a follow-up, so this PR stays reviewable:

- **Join keys.** v0.2 bundles moved keys into separate `references/joins/*.md` documents (`- [transactions](../references/joins/outputs___transactions.md)`), so those edges still import keyless. Restoring titles did not change this — the keys were never in the table documents.
- **New concept types.** `Metric`, `Policy`, `Skill`, `Attested Computation` and `Log` still pass the mart filter, so importing `acme_retail` whole yields 9 spurious nodes out of 10. Not reachable via the GitHub URL flow (we don't recurse into subdirectory indexes) but reachable via ZIP.
- **Type normalization** (`NUMERIC(18,4)` is outside our set) and **footnote markers** (`[^warehouse-schema]`) left in descriptions.
- **Export-side v0.2 signals** (`okf_version`, `generated`, `verified`, `resource`) — needs a matching change in `OWOX/models` `export.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjYErFEHUy2JHq8PB2XLCe
