### PR TITLE
fix(push): normalise field types, push keyless joins, stop truncating OWOX errors

### DIFF
--- a/packages/okf/src/fieldType.ts
+++ b/packages/okf/src/fieldType.ts
@@ -1,0 +1,94 @@
+// Canonical OWOX schema field types and the normalisation that gets hand-written
+// or LLM-generated OKF markdown into that set.
+//
+// OWOX validates a mart's output schema with a per-engine Zod enum and the enum
+// is CASE-SENSITIVE. Confirmed live against app.owox.com for GOOGLE_BIGQUERY:
+//   INTEGER FLOAT NUMERIC BIGNUMERIC STRING BYTES BOOLEAN DATE TIME DATETIME
+//   TIMESTAMP GEOGRAPHY JSON RECORD STRUCT RANGE INTERVAL
+// Anything else — `bool`, `text`, `int64`, `decimal(10,2)`, lowercase `string` —
+// is rejected with 400 "Invalid enum value … received 'x'", which used to reach
+// the user only as an unactionable schema error at push time.
+//
+// The canonical set IS the BigQuery enum. Engine-specific types that BigQuery has
+// no member for — Snowflake's VARIANT above all — are deliberately absent and are
+// mapped onto their BigQuery equivalent instead (VARIANT → JSON), because offering
+// a type the target engine rejects only produces a 400 at push time.
+// NOTE: only the BigQuery enum is confirmed live. If a Snowflake storage ever needs
+// VARIANT back, make the mapping engine-aware rather than widening this set.
+export const FIELD_TYPES = [
+  "STRING", "INTEGER", "FLOAT", "NUMERIC", "BIGNUMERIC", "BOOLEAN",
+  "DATE", "TIME", "DATETIME", "TIMESTAMP", "BYTES", "GEOGRAPHY",
+  "JSON", "RECORD", "STRUCT", "RANGE", "INTERVAL",
+] as const;
+
+/** What the canvas offers in the field-type picker: the canonical set minus types
+ *  that are valid but effectively never hand-picked while modelling — nested
+ *  containers (RECORD/STRUCT), BigQuery exotica (RANGE/INTERVAL) and BIGNUMERIC.
+ *  They still survive import and push; they just don't clutter the dropdown, and
+ *  a field that already carries one keeps it (see SchemaEditor). */
+export const EDITOR_FIELD_TYPES = FIELD_TYPES.filter(
+  t => !["RECORD", "STRUCT", "RANGE", "INTERVAL", "BIGNUMERIC"].includes(t),
+);
+
+const CANONICAL = new Set<string>(FIELD_TYPES);
+
+// Spellings of the same type from other SQL dialects (Postgres, MySQL, Snowflake,
+// BigQuery's standard-SQL names) mapped onto the canonical name.
+const ALIASES: Record<string, string> = {
+  // integers
+  INT: "INTEGER", INT2: "INTEGER", INT4: "INTEGER", INT8: "INTEGER", INT32: "INTEGER", INT64: "INTEGER",
+  TINYINT: "INTEGER", SMALLINT: "INTEGER", MEDIUMINT: "INTEGER", BIGINT: "INTEGER", BYTEINT: "INTEGER",
+  LONG: "INTEGER", SERIAL: "INTEGER", BIGSERIAL: "INTEGER",
+  // floats
+  FLOAT4: "FLOAT", FLOAT8: "FLOAT", FLOAT64: "FLOAT", DOUBLE: "FLOAT", "DOUBLE PRECISION": "FLOAT", REAL: "FLOAT",
+  // fixed point
+  DECIMAL: "NUMERIC", DEC: "NUMERIC", FIXED: "NUMERIC", NUMBER: "NUMERIC", MONEY: "NUMERIC",
+  BIGDECIMAL: "BIGNUMERIC",
+  // strings
+  BOOL: "BOOLEAN",
+  TEXT: "STRING", VARCHAR: "STRING", NVARCHAR: "STRING", CHAR: "STRING", NCHAR: "STRING",
+  CHARACTER: "STRING", "CHARACTER VARYING": "STRING", CLOB: "STRING", UUID: "STRING", ENUM: "STRING",
+  // dates & times
+  TIMESTAMPTZ: "TIMESTAMP", TIMESTAMP_TZ: "TIMESTAMP", TIMESTAMP_LTZ: "TIMESTAMP", TIMESTAMP_NTZ: "TIMESTAMP",
+  "TIMESTAMP WITH TIME ZONE": "TIMESTAMP", "TIMESTAMP WITHOUT TIME ZONE": "TIMESTAMP",
+  DATETIME2: "DATETIME", DATETIMEOFFSET: "TIMESTAMP", SMALLDATETIME: "DATETIME", EPOCH: "TIMESTAMP",
+  // binary
+  BINARY: "BYTES", VARBINARY: "BYTES", BLOB: "BYTES", BYTEA: "BYTES",
+  // semi-structured & spatial. VARIANT is Snowflake's schemaless container; its
+  // BigQuery counterpart is JSON, so a bundle authored for Snowflake still pushes.
+  JSONB: "JSON", OBJECT: "JSON", MAP: "JSON", VARIANT: "JSON", XML: "JSON",
+  GEOMETRY: "GEOGRAPHY", POINT: "GEOGRAPHY",
+};
+
+/** Fallback for a type we cannot recognise. STRING is the only safe guess: it is
+ *  valid in every OWOX engine, so the mart's schema still reaches OWOX and the
+ *  user can correct one field instead of losing the whole schema to a 400. */
+export const DEFAULT_FIELD_TYPE = "STRING";
+
+/**
+ * Coerce a raw type spelling into a canonical OWOX field type.
+ * Handles case, parameters (`NUMERIC(10,2)`), array/repeated wrappers
+ * (`ARRAY<STRING>`, `STRING[]` → the element type) and dialect aliases.
+ * Unrecognised input falls back to STRING rather than being passed through —
+ * passing it through is what makes OWOX reject the whole schema.
+ */
+export function normalizeFieldType(raw: string | null | undefined): string {
+  let t = (raw ?? "").trim().toUpperCase();
+  if (!t) return DEFAULT_FIELD_TYPE;
+
+  // Unwrap array notations down to the element type. OWOX has no ARRAY member —
+  // repeatedness lives in `mode`, which the canvas does not model.
+  for (let i = 0; i < 3; i++) {
+    const wrapped = t.match(/^(?:ARRAY|REPEATED|LIST|SET)\s*[<(]\s*(.+?)\s*[>)]$/) ?? t.match(/^(.+?)\s*\[\s*\]$/);
+    if (!wrapped) break;
+    t = wrapped[1].trim();
+  }
+
+  // Drop precision/length parameters, but keep STRUCT/RECORD field lists out of
+  // the way first — STRUCT<a INT64> is still a STRUCT.
+  if (/^(STRUCT|RECORD)\b/.test(t)) return t.startsWith("RECORD") ? "RECORD" : "STRUCT";
+  t = t.replace(/\s*\([^)]*\)\s*$/, "").trim();
+
+  if (CANONICAL.has(t)) return t;
+  return ALIASES[t] ?? DEFAULT_FIELD_TYPE;
+}

--- a/packages/okf/src/index.ts
+++ b/packages/okf/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export { slugify, parseFrontmatter, renderFrontmatter } from "./slug";
 export { serializeBundle, type OkfBundle } from "./serialize";
 export { parseBundle } from "./parse";
+export { FIELD_TYPES, EDITOR_FIELD_TYPES, DEFAULT_FIELD_TYPE, normalizeFieldType } from "./fieldType";

--- a/packages/okf/src/parse.ts
+++ b/packages/okf/src/parse.ts
@@ -1,5 +1,6 @@
 import type { ModelGraph, ModelNode, ModelEdge, InputSource, Cardinality, SchemaField } from "./types";
 import { parseFrontmatter } from "./slug";
+import { normalizeFieldType } from "./fieldType";
 
 const FLIP_CARDINALITY: Record<Cardinality, Cardinality> = { "1:1": "1:1", "N:N": "N:N", "1:N": "N:1", "N:1": "1:N" };
 
@@ -208,7 +209,10 @@ function parseSchema(body: string): SchemaField[] {
     const at = (i: number) => (i >= 0 ? cells[i] ?? "" : "");
     const name = fieldName(at(idxName));
     if (!name) continue;
-    const field: SchemaField = { name, type: at(idxType) || "STRING", pk: false };
+    // The type cell is free text in hand-written / LLM-generated bundles, so it
+    // is normalised rather than trusted: OWOX's schema enum is case-sensitive and
+    // rejects the whole mart schema over one `bool` or `decimal(10,2)`.
+    const field: SchemaField = { name, type: normalizeFieldType(at(idxType)), pk: false };
     if (idxPk >= 0) field.pk = /^(✓|x|X)$/.test(at(idxPk));
     let desc = at(idxDesc);
     if (/^PK\.\s*/.test(desc)) { field.pk = true; desc = desc.replace(/^PK\.\s*/, "").trim(); }
@@ -264,7 +268,9 @@ function parseFieldRest(name: string, rest: string): SchemaField {
     const colon = tail.indexOf(":");
     description = colon >= 0 ? tail.slice(colon + 1).trim() : "";
   }
-  const field: SchemaField = { name, type, pk: false };
+  // TYPE_WORDS deliberately accepts dialect spellings (INT64, BOOL, STRUCT …);
+  // normalisation maps them onto the canonical names OWOX actually accepts.
+  const field: SchemaField = { name, type: normalizeFieldType(type), pk: false };
   if (description) field.description = description;
   return field;
 }

--- a/packages/okf/test/fieldType.test.ts
+++ b/packages/okf/test/fieldType.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { normalizeFieldType, FIELD_TYPES, EDITOR_FIELD_TYPES } from "../src/fieldType";
+import { parseBundle } from "../src/parse";
+
+// The enum OWOX validates a BigQuery mart schema against — confirmed live
+// (PUT /api/data-marts/{id}/schema returns the full list in its 400 body).
+const BIGQUERY_ENUM = [
+  "INTEGER", "FLOAT", "NUMERIC", "BIGNUMERIC", "STRING", "BYTES", "BOOLEAN", "DATE",
+  "TIME", "DATETIME", "TIMESTAMP", "GEOGRAPHY", "JSON", "RECORD", "STRUCT", "RANGE", "INTERVAL",
+];
+
+describe("normalizeFieldType", () => {
+  it("passes canonical types through", () => {
+    for (const t of FIELD_TYPES) expect(normalizeFieldType(t)).toBe(t);
+  });
+
+  it("uppercases — OWOX's enum is case-sensitive", () => {
+    expect(normalizeFieldType("string")).toBe("STRING");
+    expect(normalizeFieldType("Timestamp")).toBe("TIMESTAMP");
+    expect(normalizeFieldType(" boolean ")).toBe("BOOLEAN");
+  });
+
+  it("maps dialect aliases", () => {
+    expect(normalizeFieldType("INT64")).toBe("INTEGER");
+    expect(normalizeFieldType("bigint")).toBe("INTEGER");
+    expect(normalizeFieldType("FLOAT64")).toBe("FLOAT");
+    expect(normalizeFieldType("double precision")).toBe("FLOAT");
+    expect(normalizeFieldType("DECIMAL")).toBe("NUMERIC");
+    expect(normalizeFieldType("BOOL")).toBe("BOOLEAN");
+    expect(normalizeFieldType("text")).toBe("STRING");
+    expect(normalizeFieldType("uuid")).toBe("STRING");
+    expect(normalizeFieldType("timestamptz")).toBe("TIMESTAMP");
+    expect(normalizeFieldType("jsonb")).toBe("JSON");
+    expect(normalizeFieldType("bytea")).toBe("BYTES");
+  });
+
+  it("drops precision and length parameters", () => {
+    expect(normalizeFieldType("NUMERIC(10,2)")).toBe("NUMERIC");
+    expect(normalizeFieldType("varchar(255)")).toBe("STRING");
+    expect(normalizeFieldType("decimal(38, 9)")).toBe("NUMERIC");
+  });
+
+  it("unwraps array notations to the element type", () => {
+    expect(normalizeFieldType("ARRAY<STRING>")).toBe("STRING");
+    expect(normalizeFieldType("array<int64>")).toBe("INTEGER");
+    expect(normalizeFieldType("STRING[]")).toBe("STRING");
+  });
+
+  it("keeps nested structs as STRUCT/RECORD", () => {
+    expect(normalizeFieldType("STRUCT<name STRING, age INT64>")).toBe("STRUCT");
+    expect(normalizeFieldType("record")).toBe("RECORD");
+  });
+
+  it("falls back to STRING for empty or unknown input", () => {
+    expect(normalizeFieldType("")).toBe("STRING");
+    expect(normalizeFieldType(undefined)).toBe("STRING");
+    expect(normalizeFieldType("Полное имя")).toBe("STRING");
+    expect(normalizeFieldType("hll_sketch")).toBe("STRING");
+  });
+
+  it("never emits a type outside the canonical set", () => {
+    const probes = ["int", "bool", "text", "datetime2", "smallmoney", "clob", "geometry", "??", "STRUCT<x INT>"];
+    for (const p of probes) expect(FIELD_TYPES as readonly string[]).toContain(normalizeFieldType(p));
+  });
+
+  // The guarantee the canvas rests on: nothing we can produce or offer is rejected
+  // by OWOX's BigQuery schema validation.
+  it("every canonical type is a member of OWOX's BigQuery enum", () => {
+    expect(FIELD_TYPES.filter(t => !BIGQUERY_ENUM.includes(t))).toEqual([]);
+  });
+
+  it("maps Snowflake's VARIANT onto BigQuery's JSON instead of offering it", () => {
+    expect(normalizeFieldType("VARIANT")).toBe("JSON");
+    expect(normalizeFieldType("variant")).toBe("JSON");
+    expect(FIELD_TYPES as readonly string[]).not.toContain("VARIANT");
+  });
+});
+
+describe("EDITOR_FIELD_TYPES", () => {
+  it("is a subset of the canonical set", () => {
+    for (const t of EDITOR_FIELD_TYPES) expect(FIELD_TYPES as readonly string[]).toContain(t);
+  });
+
+  it("offers the everyday types and hides the exotic ones", () => {
+    expect(EDITOR_FIELD_TYPES).toEqual([
+      "STRING", "INTEGER", "FLOAT", "NUMERIC", "BOOLEAN",
+      "DATE", "TIME", "DATETIME", "TIMESTAMP", "BYTES", "GEOGRAPHY", "JSON",
+    ]);
+  });
+});
+
+describe("parseBundle field types", () => {
+  it("normalises types from a schema table", () => {
+    const md = `---
+title: Sessions
+---
+
+# Schema
+
+| Name | Type | Description |
+| --- | --- | --- |
+| session_id | string | PK. Session key. |
+| starts_at | datetime | Local start. |
+| price | decimal(10,2) | Ticket price. |
+| is_paid | bool | Paid flag. |
+| room_ids | ARRAY<INT64> | Rooms. |
+| notes | mystery | Free text. |
+`;
+    const g = parseBundle({ "sessions.md": md });
+    expect(g.nodes[0].schema.map(f => f.type)).toEqual([
+      "STRING", "DATETIME", "NUMERIC", "BOOLEAN", "INTEGER", "STRING",
+    ]);
+  });
+
+  it("normalises types from a bullet-list schema", () => {
+    const md = `---
+title: Tickets
+---
+
+# Schema
+
+- \`ticket_id\` (INT64): Ticket key.
+- \`issued_at\` (Timestamp): When it was issued.
+- \`is_void\` (BOOL): Voided flag.
+`;
+    const g = parseBundle({ "tickets.md": md });
+    expect(g.nodes[0].schema.map(f => f.type)).toEqual(["INTEGER", "TIMESTAMP", "BOOLEAN"]);
+  });
+});

--- a/packages/server/src/owox/client.ts
+++ b/packages/server/src/owox/client.ts
@@ -48,6 +48,28 @@ export function decodeProjectFromToken(token: string): { projectTitle?: string; 
   } catch { return {}; }
 }
 
+// OWOX puts the actionable part of a validation error at the END of its message
+// ("Invalid enum value. Expected 'INTEGER' | … , received 'VARIANT'"), so slicing
+// the head off a raw error body hides exactly the bit the user needs — the enum
+// list alone eats ~300 chars. Prefer the JSON `message` over the whole envelope
+// (which repeats the path and timestamp) and, when it still must be shortened,
+// keep both ends.
+const MAX_ERROR_DETAIL = 600;
+
+export function owoxErrorDetail(body: string): string {
+  let detail = body;
+  try {
+    const j = JSON.parse(body) as { message?: unknown; error?: unknown };
+    const msg = Array.isArray(j.message) ? j.message.join("; ") : j.message;
+    if (typeof msg === "string" && msg) detail = msg;
+    else if (typeof j.error === "string" && j.error) detail = j.error;
+  } catch { /* not JSON — keep the raw body */ }
+  detail = detail.replace(/\s+/g, " ").trim();
+  if (detail.length <= MAX_ERROR_DETAIL) return detail;
+  const head = Math.ceil((MAX_ERROR_DETAIL - 1) / 2);
+  return `${detail.slice(0, head)}…${detail.slice(head - (MAX_ERROR_DETAIL - 1))}`;
+}
+
 export class OwoxClient {
   constructor(private origin: string, private token: string, private keyId: string, private f: FetchFn = fetch) {}
   // Every /api/* call needs BOTH x-owox-authorization AND X-OWOX-Api-Key-Id;
@@ -55,7 +77,10 @@ export class OwoxClient {
   private h() { return { "x-owox-authorization": `Bearer ${this.token}`, "X-OWOX-Api-Key-Id": this.keyId, "Content-Type": "application/json" }; }
   private async json<T>(method: string, path: string, body?: unknown): Promise<T> {
     const res = await this.f(`${this.origin}${path}`, { method, headers: this.h(), body: body ? JSON.stringify(body) : undefined });
-    if (!res.ok) throw new Error(`OWOX ${method} ${path} -> ${res.status} ${await res.text().catch(() => "")}`.slice(0, 300));
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`OWOX ${method} ${path} -> ${res.status} ${owoxErrorDetail(body)}`);
+    }
     return (res.status === 204 ? undefined : await res.json()) as T;
   }
   async listDataMarts(): Promise<DataMartListItem[]> {

--- a/packages/server/test/client.test.ts
+++ b/packages/server/test/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseApiKey, exchangeToken, OwoxClient } from "../src/owox/client";
+import { parseApiKey, exchangeToken, OwoxClient, owoxErrorDetail } from "../src/owox/client";
 import list from "./fixtures/owox-list.json";
 import detail from "./fixtures/owox-detail.json";
 import graph from "./fixtures/owox-relationships-graph.json";
@@ -54,6 +54,53 @@ describe("OwoxClient.listDataMarts", () => {
     const headers = (fetchMock.mock.calls[0][1] as any).headers;
     expect(headers["x-owox-authorization"]).toBe("Bearer tok_1");
     expect(headers["X-OWOX-Api-Key-Id"]).toBe("kid_1");
+  });
+});
+
+// Verbatim 400 body from the live API (PUT /schema with an invalid field type).
+// The part that tells the user what to fix — "received 'VARIANT'" — is at the very
+// end, which is why the error must never be shortened from the front.
+const SCHEMA_400 = JSON.stringify({
+  statusCode: 400,
+  timestamp: "2026-08-06T17:53:04.453Z",
+  path: "/api/data-marts/6236005d-79bd-4615-8d57-ed42dbeb71e0/schema",
+  message:
+    "Failed to validate BigQuery schema:\nInvalid enum value. Expected 'INTEGER' | 'FLOAT' | 'NUMERIC' | " +
+    "'BIGNUMERIC' | 'STRING' | 'BYTES' | 'BOOLEAN' | 'DATE' | 'TIME' | 'DATETIME' | 'TIMESTAMP' | " +
+    "'GEOGRAPHY' | 'JSON' | 'RECORD' | 'STRUCT' | 'RANGE' | 'INTERVAL', received 'VARIANT'",
+  errorDetails: { zodErrors: [{ received: "VARIANT", code: "invalid_enum_value", path: ["fields", 0, "type"] }] },
+});
+
+describe("owoxErrorDetail", () => {
+  it("keeps the received value — the only actionable part of a schema 400", () => {
+    const detail = owoxErrorDetail(SCHEMA_400);
+    expect(detail).toContain("received 'VARIANT'");
+    expect(detail).toContain("Failed to validate BigQuery schema");
+    expect(detail).not.toContain("timestamp"); // envelope noise is dropped
+  });
+
+  it("joins Nest's array-shaped message", () => {
+    expect(owoxErrorDetail(JSON.stringify({ message: ["a must be an array", "b is required"] })))
+      .toBe("a must be an array; b is required");
+  });
+
+  it("falls back to `error`, then to the raw body", () => {
+    expect(owoxErrorDetail(JSON.stringify({ error: "Bad Request" }))).toBe("Bad Request");
+    expect(owoxErrorDetail("<html>502 Bad Gateway</html>")).toBe("<html>502 Bad Gateway</html>");
+  });
+
+  it("keeps both ends when it has to shorten", () => {
+    const long = `START${"x".repeat(2000)}received 'DATETIME'`;
+    const out = owoxErrorDetail(JSON.stringify({ message: long }));
+    expect(out.length).toBeLessThanOrEqual(600);
+    expect(out.startsWith("START")).toBe(true);
+    expect(out.endsWith("received 'DATETIME'")).toBe(true);
+  });
+
+  it("surfaces the full detail through a failed request", async () => {
+    const fetchMock = vi.fn(async () => new Response(SCHEMA_400, { status: 400 }));
+    const c = new OwoxClient("https://app.owox.com", "tok", "kid", fetchMock as any);
+    await expect(c.updateSchema("id_1", {})).rejects.toThrow(/received 'VARIANT'/);
   });
 });
 

--- a/packages/web/public/ai-instructions.html
+++ b/packages/web/public/ai-instructions.html
@@ -189,8 +189,9 @@ SELECT id, customer_id, order_date, total FROM `project.dataset.orders`
 |--------|------|-------|-------------|
 | `id` | STRING | | PK. Unique order identifier |
 | `total` | FLOAT | Order Total | Order total, gross |</code></pre>
-  <p><b>Allowed types</b> (cross-storage canonical set — do not use others like <code>DATETIME</code>):</p>
-  <p><span class="chip">STRING</span><span class="chip">INTEGER</span><span class="chip">FLOAT</span><span class="chip">NUMERIC</span><span class="chip">BOOLEAN</span><span class="chip">DATE</span><span class="chip">TIME</span><span class="chip">TIMESTAMP</span><span class="chip">BYTES</span><span class="chip">GEOGRAPHY</span><span class="chip">VARIANT</span></p>
+  <p><b>Preferred types</b> (the set OWOX accepts, verified against its schema validation):</p>
+  <p><span class="chip">STRING</span><span class="chip">INTEGER</span><span class="chip">FLOAT</span><span class="chip">NUMERIC</span><span class="chip">BOOLEAN</span><span class="chip">DATE</span><span class="chip">TIME</span><span class="chip">DATETIME</span><span class="chip">TIMESTAMP</span><span class="chip">BYTES</span><span class="chip">GEOGRAPHY</span><span class="chip">JSON</span></p>
+  <p>Other spellings are normalised on import — <code>int64</code>, <code>bool</code>, <code>text</code>, <code>decimal(10,2)</code>, <code>timestamptz</code>, <code>ARRAY&lt;STRING&gt;</code> and Snowflake's <code>VARIANT</code> all land on the right type, and anything unrecognised becomes <code>STRING</code>. So an odd cell costs you one field, never the whole schema.</p>
 
   <h2>5. Definition (optional)</h2>
   <p>Optionally include a <code>## Definition</code> fenced code block. Its meaning depends on the <b>Definition type</b> in Overview:</p>

--- a/packages/web/public/okf-format.md
+++ b/packages/web/public/okf-format.md
@@ -120,8 +120,11 @@ A 3-column table: **Column** (name in backticks), **Type**, **Description** — 
   | `id` | STRING | | PK. Unique order identifier |
   | `total` | FLOAT | Order Total | Order total, gross |
   ```
-- **Allowed types only** (cross-storage set — do NOT use others like DATETIME):
-  `STRING` `INTEGER` `FLOAT` `NUMERIC` `BOOLEAN` `DATE` `TIME` `TIMESTAMP` `BYTES` `GEOGRAPHY` `VARIANT`
+- **Preferred types** (the set OWOX accepts, verified against its schema validation):
+  `STRING` `INTEGER` `FLOAT` `NUMERIC` `BOOLEAN` `DATE` `TIME` `DATETIME` `TIMESTAMP` `BYTES` `GEOGRAPHY` `JSON`
+  Other spellings are normalised on import — `int64`, `bool`, `text`, `decimal(10,2)`,
+  `timestamptz`, `ARRAY<STRING>` and Snowflake's `VARIANT` all land on the right type
+  (anything unrecognised becomes `STRING`), so a bundle never loses its schema to one odd cell.
 
 ### `## Definition` (optional)
 A fenced code block; its meaning follows the Definition type:

--- a/packages/web/src/components/PushToast.test.tsx
+++ b/packages/web/src/components/PushToast.test.tsx
@@ -5,7 +5,7 @@ import type { PushResult } from "../sync/push";
 
 const result = (over: Partial<PushResult> = {}): PushResult => ({
   created: 0, updated: 0, failed: 0, blocked: 0,
-  relationshipsCreated: 0, relationshipsFailed: 0, errors: [], ...over,
+  relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [], ...over,
 });
 
 describe("PushToast", () => {
@@ -37,6 +37,18 @@ describe("PushToast", () => {
   it("still flags real failures", () => {
     render(<PushToast result={result({ created: 1, failed: 2, errors: ["boom"] })} onClose={() => {}} />);
     expect(screen.getByText(/push completed with errors/i)).toBeTruthy();
-    expect(screen.getByText(/2 failed/)).toBeTruthy();
+    expect(screen.getByText(/2 marts failed/)).toBeTruthy();
+  });
+
+  it("counts failed marts and failed links apart", () => {
+    render(<PushToast result={result({ created: 10, failed: 1, relationshipsFailed: 14, errors: ["boom"] })} onClose={() => {}} />);
+    expect(screen.getByText(/1 mart failed, 14 links failed/)).toBeTruthy();
+  });
+
+  it("notes links pushed without join keys", () => {
+    render(<PushToast result={result({ created: 2, relationshipsCreated: 3, relationshipsWithoutKeys: 3 })} onClose={() => {}} />);
+    expect(screen.getByText("Push complete")).toBeTruthy();
+    expect(screen.getByText(/3 links have no join keys yet/i)).toBeTruthy();
+    expect(screen.getByText(/Join not configured/i)).toBeTruthy();
   });
 });

--- a/packages/web/src/components/PushToast.tsx
+++ b/packages/web/src/components/PushToast.tsx
@@ -8,6 +8,7 @@ import type { PushResult } from "../sync/push";
 // so it gets its own headline instead of the success one.
 export function PushToast({ result, onClose }: { result: PushResult; onClose: () => void }) {
   const blocked = result.blocked ?? 0;
+  const keyless = result.relationshipsWithoutKeys ?? 0;
   const failed = result.failed + result.relationshipsFailed;
   const pushedNothing = result.created === 0 && result.relationshipsCreated === 0;
 
@@ -20,7 +21,10 @@ export function PushToast({ result, onClose }: { result: PushResult; onClose: ()
   const parts: string[] = [];
   if (result.created > 0 || blocked === 0) parts.push(`${result.created} mart${result.created === 1 ? "" : "s"} created`);
   if (result.relationshipsCreated) parts.push(`${result.relationshipsCreated} link${result.relationshipsCreated === 1 ? "" : "s"} created`);
-  if (failed) parts.push(`${failed} failed`);
+  // Marts and links are counted apart: a bare "14 failed" next to "10 marts
+  // created" reads as if marts had failed, when it was only the links.
+  if (result.failed) parts.push(`${result.failed} mart${result.failed === 1 ? "" : "s"} failed`);
+  if (result.relationshipsFailed) parts.push(`${result.relationshipsFailed} link${result.relationshipsFailed === 1 ? "" : "s"} failed`);
 
   const dot = tone === "error" ? "bg-red-500" : tone === "warn" ? "bg-amber-500" : "bg-emerald-500";
   const border = tone === "error" ? "border-red-300" : tone === "warn" ? "border-amber-300" : "border-emerald-300";
@@ -33,6 +37,12 @@ export function PushToast({ result, onClose }: { result: PushResult; onClose: ()
           {title}
           {parts.length > 0 && (
             <div className="font-normal text-slate-500 text-[12px] mt-0.5">{parts.join(", ")}</div>
+          )}
+          {keyless > 0 && (
+            <div className="font-normal text-[12px] mt-1 text-slate-500 leading-snug">
+              {keyless} {keyless === 1 ? "link has" : "links have"} no join keys yet — {keyless === 1 ? "it was" : "they were"} created
+              in OWOX as “Join not configured”. Pick the join fields here or in OWOX to make {keyless === 1 ? "it" : "them"} usable in reports.
+            </div>
           )}
           {blocked > 0 && (
             <div className="font-normal text-[12px] mt-1 text-[#8a5a00] leading-snug">

--- a/packages/web/src/components/canvas/Canvas.pushgate.test.tsx
+++ b/packages/web/src/components/canvas/Canvas.pushgate.test.tsx
@@ -15,7 +15,7 @@ vi.mock("../../lib/api", () => ({ api: (path: string, opts?: RequestInit) => api
 // ── Mock the push entrypoint so we can assert it was (not) called without
 // doing any real push work.
 const pushModel = vi.fn(async () => ({
-  created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [],
+  created: 0, updated: 0, failed: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [],
 }));
 vi.mock("../../sync/push", () => ({ pushModel: (...args: Parameters<typeof pushModel>) => pushModel(...args) }));
 

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -748,7 +748,7 @@ function CanvasInner() {
       const result = await pushModel(store, undefined, storageType, opts);
       setPushResult(result);
     } catch (e) {
-      setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [(e as Error).message] });
+      setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [(e as Error).message] });
     } finally {
       setPushing(false);
     }
@@ -926,7 +926,7 @@ function CanvasInner() {
             const list = await loadStorages();
             if (mode === "push") {
               if (list.length === 0) {
-                setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
+                setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
                 return;
               }
               await runPush(list);

--- a/packages/web/src/components/inspector/SchemaEditor.tsx
+++ b/packages/web/src/components/inspector/SchemaEditor.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { GripVertical } from "lucide-react";
-import type { SchemaField } from "@mc/okf";
+import { type SchemaField, EDITOR_FIELD_TYPES } from "@mc/okf";
 import { InfoTip } from "./InfoTip";
 
-// Canonical OWOX schema types — the set accepted across storages (BigQuery,
-// Snowflake, …). Note: no DATETIME (not in the cross-storage enum).
-const FIELD_TYPES = ["STRING", "INTEGER", "FLOAT", "NUMERIC", "BOOLEAN", "DATE", "TIME", "TIMESTAMP", "BYTES", "GEOGRAPHY", "VARIANT"];
+// One source of truth for types — see @mc/okf/fieldType. Every entry is a member of
+// OWOX's BigQuery enum (confirmed live), so a pick here can never fail the schema
+// push: DATETIME is offered, Snowflake's VARIANT is gone (it normalises to JSON).
+const FIELD_TYPES: string[] = [...EDITOR_FIELD_TYPES];
 
 interface SchemaEditorProps {
   schema: SchemaField[];
@@ -91,7 +92,10 @@ export function SchemaEditor({ schema, onChange }: SchemaEditorProps) {
                 onChange={e => updateField(i, { type: e.target.value })}
                 className="w-full text-[11.5px] px-[6px] py-[5px] border border-[#d8dee8] rounded-lg text-slate-900 focus:outline-none focus:border-[#1e88e5] focus:ring-2 focus:ring-[#e6f1fb]"
               >
-                {FIELD_TYPES.map(t => (
+                {/* An imported field can carry a type the picker hides (e.g. RECORD);
+                    keep it as an option so opening the inspector can't silently
+                    rewrite it to the first entry in the list. */}
+                {(FIELD_TYPES.includes(field.type) ? FIELD_TYPES : [field.type, ...FIELD_TYPES]).map(t => (
                   <option key={t} value={t}>{t}</option>
                 ))}
               </select>

--- a/packages/web/src/sync/push.ts
+++ b/packages/web/src/sync/push.ts
@@ -1,6 +1,6 @@
 import type { ModelStore } from "../state/model";
 import { api as defaultApi } from "../lib/api";
-import { type ModelNode, type ModelGraph } from "@mc/okf";
+import { type ModelNode, type ModelGraph, normalizeFieldType } from "@mc/okf";
 import { joinFieldType, alignedJoinTypes } from "./joinFieldType";
 
 type Api = typeof defaultApi;
@@ -14,6 +14,9 @@ export interface PushResult {
   blocked: number;
   relationshipsCreated: number;
   relationshipsFailed: number;
+  /** Links created as "Join not configured" in OWOX because the canvas edge has no
+   *  join keys yet. Counted separately: they were created, but need finishing. */
+  relationshipsWithoutKeys: number;
   errors: string[];
 }
 
@@ -76,7 +79,7 @@ async function findBlockedMarts(store: ModelStore, api: Api, storageId: string):
 }
 
 export async function pushModel(store: ModelStore, api: Api = defaultApi, storageType?: string, opts: PushOptions = {}): Promise<PushResult> {
-  const res: PushResult = { created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, errors: [] };
+  const res: PushResult = { created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [] };
 
   const storageId = store.get().storageId;
   if (!storageId) {
@@ -166,8 +169,12 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
             body: JSON.stringify({
               schema: {
                 type: schemaDiscriminator(storageType),
+                // Normalise the type here too, not only on import: models saved
+                // before normalisation existed (or hand-edited) can still carry a
+                // spelling OWOX's case-sensitive enum rejects, and one bad field
+                // costs the mart its whole schema.
                 fields: fields.map(f => ({
-                  name: f.name, type: f.type, mode: "NULLABLE",
+                  name: f.name, type: normalizeFieldType(f.type), mode: "NULLABLE",
                   status: "CONNECTED", description: f.description ?? "", isPrimaryKey: f.pk,
                   ...(f.alias ? { alias: f.alias } : {}),
                 })),
@@ -207,10 +214,9 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
     for (const [fromKey, toKey, ks] of directions) {
       const fromId = owoxIdByKey.get(fromKey);
       const toId = owoxIdByKey.get(toKey);
-      if (!fromId || !toId || ks.length === 0) {
+      if (!fromId || !toId) {
         res.relationshipsFailed++;
-        const why = ks.length === 0 ? "join keys are empty" : "both marts must be created first";
-        res.errors.push(`Link ${titleByKey.get(fromKey)} → ${titleByKey.get(toKey)}: ${why}`);
+        res.errors.push(`Link ${titleByKey.get(fromKey)} → ${titleByKey.get(toKey)}: both marts must be created first`);
         continue;
       }
       try {
@@ -218,6 +224,12 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
           method: "POST",
           // NOTE: cardinality (e.cardinality) is intentionally NOT sent — it is a
           // view-only modeling annotation; OWOX's generated SQL aggregates joins.
+          //
+          // An edge with no join keys is still pushed, with joinConditions: [] —
+          // OWOX accepts that (confirmed live: 201) and shows the link as "Join not
+          // configured", so the modelled relationship survives the round trip and
+          // the keys can be picked in either tool. The field must be present: OWOX
+          // 400s on a missing joinConditions ("must be an array").
           body: JSON.stringify({
             targetDataMartId: toId,
             targetAlias: aliasify(titleByKey.get(toKey) || toKey, toKey),
@@ -225,6 +237,7 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
           }),
         });
         res.relationshipsCreated++;
+        if (ks.length === 0) res.relationshipsWithoutKeys++;
       } catch (e) {
         res.relationshipsFailed++;
         res.errors.push(`Link ${titleByKey.get(fromKey)} → ${titleByKey.get(toKey)}: ${(e as Error).message}`);

--- a/packages/web/test/push.test.ts
+++ b/packages/web/test/push.test.ts
@@ -413,4 +413,75 @@ describe("pushModel", () => {
     await pushModel(s, apiMock as any);
     expect(s.get().nodes.find(n => n.key === "newobj")!.schema.find(f => f.name === "id")!.type).toBe("INTEGER");
   });
+
+  // A link drawn on the canvas starts with no join keys. OWOX accepts a
+  // relationship with joinConditions: [] (confirmed live: 201) and shows it as
+  // "Join not configured", so the link is pushed instead of reported as an error.
+  it("pushes a keyless edge as an unconfigured join instead of failing it", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Session", inputSource: "SQL", schema: [{ name: "id", type: "STRING", pk: true }], position: { x: 0, y: 0 }, status: "created", owoxId: "owox_a", owoxStorageId: "stor_1" },
+        { key: "n2", title: "Room", inputSource: "SQL", schema: [{ name: "id", type: "STRING", pk: true }], position: { x: 100, y: 0 }, status: "created", owoxId: "owox_b", owoxStorageId: "stor_1" },
+      ],
+      edges: [{ id: "e1", from: "n1", to: "n2", keys: [{ left: "", right: "" }], bidirectional: false }],
+    });
+    const bodies: any[] = [];
+    const apiMock = vi.fn(async (path: string, init?: any) => {
+      if (path.includes("/relationships") && init?.body) bodies.push(JSON.parse(init.body));
+      return { id: "owox_rel" };
+    });
+    const res = await pushModel(s, apiMock as any);
+    expect(bodies).toHaveLength(1);
+    // The field must be present and an array — OWOX 400s when it is omitted.
+    expect(bodies[0].joinConditions).toEqual([]);
+    expect(bodies[0].targetAlias).toBe("room");
+    expect(res.relationshipsCreated).toBe(1);
+    expect(res.relationshipsWithoutKeys).toBe(1);
+    expect(res.relationshipsFailed).toBe(0);
+    expect(res.errors).toEqual([]);
+  });
+
+  it("still fails a link whose mart was never created", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    s.set({
+      storageId: "stor_1",
+      nodes: [
+        { key: "n1", title: "Session", inputSource: "SQL", schema: [], position: { x: 0, y: 0 }, status: "created", owoxId: "owox_a", owoxStorageId: "stor_1" },
+        { key: "n2", title: "Room", inputSource: "SQL", schema: [], position: { x: 100, y: 0 }, status: "pending", owoxId: null },
+      ],
+      edges: [{ id: "e1", from: "n1", to: "n2", keys: [], bidirectional: false }],
+    });
+    const apiMock = vi.fn(async (path: string) => {
+      if (path === "/api/data-marts") throw new Error("boom"); // n2 never gets an id
+      return { id: "owox_rel" };
+    });
+    const res = await pushModel(s, apiMock as any);
+    expect(res.relationshipsCreated).toBe(0);
+    expect(res.relationshipsFailed).toBe(1);
+    expect(res.errors.some(e => /both marts must be created first/.test(e))).toBe(true);
+  });
+
+  // Defence in depth for models saved before types were normalised on import:
+  // OWOX's schema enum is case-sensitive and rejects the whole mart schema over
+  // one bad field.
+  it("normalises field types in the schema body", async () => {
+    const s = createModelStore({ storageId: "stor_1" });
+    const n = s.addNode({ x: 0, y: 0 });
+    s.updateNode(n.key, { schema: [
+      { name: "id", type: "int64", pk: true },
+      { name: "starts_at", type: "Datetime", pk: false },
+      { name: "price", type: "DECIMAL(10,2)", pk: false },
+      { name: "is_paid", type: "bool", pk: false },
+    ] });
+    const bodies: Record<string, any> = {};
+    const apiMock = vi.fn(async (path: string, init?: any) => {
+      if (init?.body) bodies[path] = JSON.parse(init.body);
+      return { id: "owox_a" };
+    });
+    await pushModel(s, apiMock as any, "GOOGLE_BIGQUERY");
+    expect(bodies["/api/data-marts/owox_a/schema"].schema.fields.map((f: any) => f.type))
+      .toEqual(["INTEGER", "DATETIME", "NUMERIC", "BOOLEAN"]);
+  });
 });


### PR DESCRIPTION
## The report

A user pushed a 10-mart model from the canvas. Every mart was created, but 5 lost their output schema to `400 Invalid enum value. Expected 'INTEGER' | 'FLOAT' |` (cut off there), and **all 14** relationships failed with `join keys are empty`. The toast said "10 marts created, 14 failed", which reads as if marts had failed.

Three independent causes. All contracts below were **confirmed against the live OWOX API**, not inferred.

## 1. Field types were sent verbatim

`push.ts` passed `f.type` straight through, and nothing upstream validated it: the OKF markdown parser took the Type cell literally (`at(idxType) || "STRING"` — no case fix, no whitelist). OWOX validates a mart's schema against a **case-sensitive** per-engine Zod enum, so one `bool`, `int64`, `decimal(10,2)` or lowercase `string` costs the mart its **entire** schema.

New `normalizeFieldType()` (`packages/okf/src/fieldType.ts`) coerces case, strips parameters, unwraps array notations and maps dialect aliases onto the canonical set; anything unrecognised becomes `STRING` instead of a 400. Applied in both schema parsers (table + bullet) and **again in `push.ts`** — models already sitting in `localStorage` would otherwise keep failing.

## 2. The canonical set is now exactly OWOX's BigQuery enum

Confirmed live:

```
INTEGER FLOAT NUMERIC BIGNUMERIC STRING BYTES BOOLEAN DATE TIME
DATETIME TIMESTAMP GEOGRAPHY JSON RECORD STRUCT RANGE INTERVAL
```

Two long-standing inversions fall out of that:

- **`DATETIME` is valid** — the editor hid it and a code comment claimed it wasn't in the enum. The authoring docs went further and told AI bundle authors *"do NOT use DATETIME"*.
- **`VARIANT` is not** — it's Snowflake's semi-structured type, yet the canvas offered it in the dropdown. That is how a BigQuery push silently loses schemas.

`VARIANT` (plus `XML`/`OBJECT`/`JSONB`) now normalises to `JSON`, its BigQuery counterpart, so a bundle authored for Snowflake still pushes. The picker (`EDITOR_FIELD_TYPES`) shows the 12 everyday types and hides `RECORD`/`STRUCT`/`RANGE`/`INTERVAL`/`BIGNUMERIC` — still canonical, still preserved on import, just never hand-picked; a field that already carries one keeps it as an option so opening the inspector can't rewrite it.

`packages/web/public/okf-format.md` and `ai-instructions.html` are corrected accordingly — they were actively steering model authors toward the broken type.

## 3. Keyless links are pushed instead of rejected

A link drawn on the canvas starts as `keys: [{ left: "", right: "" }]`, and push turned that into an error. But OWOX **accepts** a relationship with no join keys:

- `joinConditions: []` → **201**, shown in ODM as *"Join not configured"* (`isBlocked: true` in the relationship graph)
- omitting the field → `400 "joinConditions must be an array."`

So the modelled relationship now survives the push and the join fields can be picked in either tool. Counted separately as `PushResult.relationshipsWithoutKeys` and surfaced as a note in `PushToast` rather than hidden.

## Also

- **OWOX errors were sliced to the first 300 chars** (`owox/client.ts`) — precisely where the actionable part is *not*: Zod puts `received 'VARIANT'` at the end, after a ~300-char enum list. That's why the user's 5 errors all looked identically truncated and unactionable. `owoxErrorDetail()` prefers the JSON `message` over the envelope (drops repeated path/timestamp), joins Nest's array-shaped messages, and keeps **both ends** when it has to shorten.
- **`PushToast` counted marts and links together.** Now: "10 marts created, 1 mart failed, 14 links failed".

## Verification

Live end-to-end run of the **real `pushModel`** against `app.owox.com` (Retail Chain project), with deliberately dirty types and a keyless edge:

```
push result: {"created":2,"failed":0,"relationshipsCreated":1,"relationshipsWithoutKeys":1,"errors":[]}
live types:  session_id:INTEGER starts_at:DATETIME price:NUMERIC
             is_paid:BOOLEAN tags:STRING payload:JSON
live graph:  1 relationship, joinConditions []
cleanup:     both probe marts deleted (200) — re-listed, 0 leftovers
```

Unit tests: **okf 79 / server 41 / web 438** green, `pnpm build` clean. New coverage: `packages/okf/test/fieldType.test.ts`, `owoxErrorDetail` in `server/test/client.test.ts` (asserted against the verbatim live 400 body), keyless-edge + normalisation cases in `web/test/push.test.ts`, two in `PushToast.test.tsx`.

## Deliberately not in scope

Only the BigQuery enum could be probed — no Snowflake storage was available. If Snowflake ever needs `VARIANT` back, the mapping should become **engine-aware** (`push.ts` already knows `storageType`) rather than widening the canonical set. Inventing an unverified Snowflake contract now would risk breaking working pushes.

A pre-push warning for fields/links that need attention *before* the request goes out is a separate UX change, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
