### PR TITLE
feat(topbar): refresh the storage list from the Storage picker

### DIFF
--- a/packages/web/src/components/TopBar.test.tsx
+++ b/packages/web/src/components/TopBar.test.tsx
@@ -20,15 +20,15 @@ describe("TopBar", () => {
 
   it("shows no storage picker when anonymous", () => {
     render(<TopBar signedIn={false} storages={storages} />);
-    expect(screen.queryByRole("combobox")).toBeNull(); // storage <select> hidden
+    expect(screen.queryByRole("button", { name: /^storage$/i })).toBeNull();
     expect(screen.queryByText("Sign in")).toBeNull();
     expect(screen.queryByText("Sign out")).toBeNull();
   });
 
-  it("shows the storage picker when signed in", () => {
+  it("shows the storage picker with the selected storage when signed in", () => {
     render(<TopBar signedIn projectTitle="Demo" storages={storages} storageId="s1" />);
     expect(screen.queryByText("Sign out")).toBeNull();
-    expect(screen.getByRole("combobox")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^storage$/i }).textContent).toMatch(/BigQuery/);
   });
 
   it("hides the Push caret menu (and its Import option) when anonymous", () => {
@@ -63,5 +63,61 @@ describe("TopBar", () => {
   it("hides the Business Goal button when the AI key is not configured", () => {
     render(<TopBar signedIn={false} onOpenGoal={() => {}} questionsEnabled={false} />);
     expect(screen.queryByRole("button", { name: /business goal/i })).toBeNull();
+  });
+});
+
+// A storage created in OWOX after the API key was added never appeared, because the
+// list is fetched once at sign-in. The picker now carries a Refresh action.
+describe("TopBar storage picker", () => {
+  const openPicker = () => fireEvent.click(screen.getByRole("button", { name: /^storage$/i }));
+
+  it("lists the storages and selects one", () => {
+    const onStorageChange = vi.fn();
+    render(<TopBar signedIn storages={[...storages, { id: "s2", title: "Snowflake", type: "SNOWFLAKE" }]} storageId="s1" onStorageChange={onStorageChange} />);
+    expect(screen.queryByRole("listbox")).toBeNull(); // closed until clicked
+    openPicker();
+    const options = screen.getAllByRole("option");
+    expect(options.map(o => o.textContent)).toEqual(["BigQuery", "Snowflake"]);
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    fireEvent.click(options[1]);
+    expect(onStorageChange).toHaveBeenCalledWith("s2");
+    expect(screen.queryByRole("listbox")).toBeNull(); // closes after picking
+  });
+
+  it("refreshes the list and keeps it open so the new storage is visible", async () => {
+    const fresh = [...storages, { id: "s2", title: "BigQuery [new]", type: "GOOGLE_BIGQUERY" }];
+    const onRefreshStorages = vi.fn(async () => fresh);
+    const { rerender } = render(<TopBar signedIn storages={storages} storageId="s1" onRefreshStorages={onRefreshStorages} />);
+    openPicker();
+    fireEvent.click(screen.getByText(/refresh the list of storages/i));
+    expect(onRefreshStorages).toHaveBeenCalledTimes(1);
+    // Canvas owns the list; mimic the re-render its setState causes.
+    rerender(<TopBar signedIn storages={fresh} storageId="s1" onRefreshStorages={onRefreshStorages} />);
+    expect(await screen.findByText(/up to date — 2 storages/i)).toBeTruthy();
+    expect(screen.getAllByRole("option").map(o => o.textContent)).toEqual(["BigQuery", "BigQuery [new]"]);
+  });
+
+  it("says the project has no storages rather than showing an empty list", async () => {
+    const onRefreshStorages = vi.fn(async () => []);
+    render(<TopBar signedIn storages={[]} onRefreshStorages={onRefreshStorages} />);
+    openPicker();
+    expect(screen.getByText(/no storages found in this project/i)).toBeTruthy();
+    fireEvent.click(screen.getByText(/refresh the list of storages/i));
+    expect(await screen.findByText(/this project has no storages yet/i)).toBeTruthy();
+  });
+
+  it("reports a failed refresh instead of leaving the list looking empty", async () => {
+    const onRefreshStorages = vi.fn(async () => { throw new Error("HTTP 500"); });
+    render(<TopBar signedIn storages={storages} storageId="s1" onRefreshStorages={onRefreshStorages} />);
+    openPicker();
+    fireEvent.click(screen.getByText(/refresh the list of storages/i));
+    expect(await screen.findByText(/couldn't reach owox/i)).toBeTruthy();
+    expect(screen.getAllByRole("option")).toHaveLength(1); // the known list is kept
+  });
+
+  it("hides the Refresh action when no handler is wired", () => {
+    render(<TopBar signedIn storages={storages} storageId="s1" />);
+    openPicker();
+    expect(screen.queryByText(/refresh the list of storages/i)).toBeNull();
   });
 });

--- a/packages/web/src/components/TopBar.tsx
+++ b/packages/web/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Download, Upload, ChevronDown, Target, FileText, Image as ImageIcon } from "lucide-react";
+import { Download, Upload, ChevronDown, Target, FileText, Image as ImageIcon, RefreshCw, Check } from "lucide-react";
 import { ProjectIcon, StorageIcon, LibraryIcon } from "../lib/icons";
 import { EnableControl } from "./EnableControl";
 
@@ -14,6 +14,10 @@ export interface TopBarProps {
   storages?: StorageOption[];
   storageId?: string | null;
   onStorageChange?: (id: string) => void;
+  /** Re-reads the project's storages from OWOX. Resolves with the fresh list;
+   *  rejects if the call failed, so the picker can tell "couldn't refresh" from
+   *  "this project genuinely has no storages". */
+  onRefreshStorages?: () => Promise<StorageOption[]>;
   onImport?: () => void;
   onImportFromOwox?: () => void;
   onExport?: () => void;
@@ -65,7 +69,7 @@ const LOGO = (
 );
 
 export function TopBar({
-  pendingCount = 0, storages = [], storageId, onStorageChange,
+  pendingCount = 0, storages = [], storageId, onStorageChange, onRefreshStorages,
   onImport, onImportFromOwox, onExport, onExportSvg, exportDisabled = false,
   onPush, onLibrary,
   signedIn, projectTitle,
@@ -76,6 +80,15 @@ export function TopBar({
 }: TopBarProps) {
   // Push split-button menu (holds the signed-in "Import from OWOX project" action).
   const [menuOpen, setMenuOpen] = useState(false);
+  // Storage picker: a custom listbox rather than a <select>, so the list can carry
+  // a Refresh action — storages created in OWOX after the API key was added would
+  // otherwise never appear without a page reload.
+  const [storageMenuOpen, setStorageMenuOpen] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  // Outcome of the last refresh, shown inside the open list. Needed because a
+  // successful refresh that changes nothing is otherwise indistinguishable from
+  // a broken one.
+  const [refreshNote, setRefreshNote] = useState<{ ok: boolean; text: string } | null>(null);
   // Export dropdown (OKF markdown / PNG / SVG).
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   // Show the Library hint on first ever visit; stays lit until hovered.
@@ -87,6 +100,28 @@ export function TopBar({
     setShowLibraryHint(false);
     try { localStorage.setItem(LIBRARY_HINT_KEY, "seen"); } catch { /* private mode */ }
   };
+
+  const closeStorageMenu = () => { setStorageMenuOpen(false); setRefreshNote(null); };
+
+  // The list stays open after a refresh — the whole point is to see what arrived.
+  const refreshStorages = async () => {
+    if (refreshing || !onRefreshStorages) return;
+    setRefreshing(true);
+    setRefreshNote(null);
+    try {
+      const list = await onRefreshStorages();
+      setRefreshNote({
+        ok: true,
+        text: list.length ? `Up to date — ${list.length} storage${list.length === 1 ? "" : "s"}` : "This project has no storages yet",
+      });
+    } catch {
+      setRefreshNote({ ok: false, text: "Couldn't reach OWOX — try again" });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const currentStorage = storages.find(s => s.id === storageId);
 
   return (
     <div className="flex items-center gap-3 px-4 py-[9px] bg-white border-b border-[#d8dee8] flex-shrink-0 z-30">
@@ -127,19 +162,67 @@ export function TopBar({
         </button>
       )}
 
-      {/* Storage picker — one storage per model (joinable requires same storage) */}
+      {/* Storage picker — one storage per model (joinable requires same storage).
+          Custom listbox instead of a <select> so the list can end with a Refresh
+          action: the storage list is fetched once at sign-in, so a storage created
+          in OWOX afterwards was previously unreachable without reloading the page. */}
       {signedIn && (
-        <label className="flex items-center gap-[7px] text-[13px] text-slate-500 border border-[#d8dee8] rounded-lg px-[10px] py-[5px] bg-white" title="One storage per model — joinable relationships require all marts on the same storage">
-          <StorageIcon size={14} /> Storage:
-          <select
-            value={storageId ?? ""}
-            onChange={e => onStorageChange?.(e.target.value)}
-            className="text-slate-900 font-semibold bg-white outline-none cursor-pointer"
+        <div className="relative" onKeyDown={e => { if (e.key === "Escape") closeStorageMenu(); }}>
+          <button
+            onClick={() => (storageMenuOpen ? closeStorageMenu() : setStorageMenuOpen(true))}
+            aria-haspopup="listbox"
+            aria-expanded={storageMenuOpen}
+            aria-label="Storage"
+            title="One storage per model — joinable relationships require all marts on the same storage"
+            className="flex items-center gap-[7px] text-[13px] text-slate-500 border border-[#d8dee8] rounded-lg px-[10px] py-[5px] bg-white cursor-pointer hover:bg-[#f1f3f7]"
           >
-            {storages.length === 0 && <option value="">—</option>}
-            {storages.map(s => <option key={s.id} value={s.id}>{s.title}</option>)}
-          </select>
-        </label>
+            <StorageIcon size={14} /> Storage:
+            <span className="text-slate-900 font-semibold">{currentStorage?.title ?? "—"}</span>
+            <ChevronDown size={14} className="text-slate-400" />
+          </button>
+          {storageMenuOpen && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={closeStorageMenu} />
+              <div role="listbox" aria-label="Storage" className="absolute top-[calc(100%+6px)] left-0 z-50 w-[268px] rounded-lg border border-[#d8dee8] bg-white shadow-[0_8px_24px_rgba(15,23,42,0.18)] py-1">
+                {storages.length === 0 && (
+                  <div className="px-3 py-2 text-[12.5px] text-slate-500 leading-snug">
+                    No storages found in this project. Create one in OWOX, then refresh below.
+                  </div>
+                )}
+                {storages.map(s => (
+                  <button
+                    key={s.id}
+                    role="option"
+                    aria-selected={s.id === storageId}
+                    onClick={() => { onStorageChange?.(s.id); closeStorageMenu(); }}
+                    className={`w-full text-left text-[13px] px-3 py-2 cursor-pointer flex items-center gap-[8px] hover:bg-[#f1f3f7] ${s.id === storageId ? "text-slate-900 font-semibold" : "text-slate-900"}`}
+                  >
+                    <Check size={14} className={s.id === storageId ? "text-[#1e88e5]" : "text-transparent"} />
+                    <span className="flex-1 truncate">{s.title}</span>
+                  </button>
+                ))}
+                {onRefreshStorages && (
+                  <>
+                    <div className="border-t border-[#eef1f5] my-1" />
+                    <button
+                      onClick={refreshStorages}
+                      disabled={refreshing}
+                      className="w-full text-left text-[13px] text-slate-600 px-3 py-2 cursor-pointer flex items-center gap-[8px] hover:bg-[#f1f3f7] disabled:cursor-default"
+                    >
+                      <RefreshCw size={14} className={`text-slate-500 ${refreshing ? "animate-spin" : ""}`} />
+                      {refreshing ? "Refreshing…" : "Refresh the list of storages"}
+                    </button>
+                    {refreshNote && (
+                      <div className={`px-3 pb-2 pt-0.5 text-[12px] leading-snug ${refreshNote.ok ? "text-slate-500" : "text-red-600"}`}>
+                        {refreshNote.text}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       )}
 
       <div className="flex-1" />

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -308,23 +308,36 @@ function CanvasInner() {
   // Load the project's storages once signed in; retry through OWOX's transient
   // 500s. Anonymous users have no session, so we skip the call entirely and
   // clear any stale list.
+  // Keep the current storage only if it's still in this project; otherwise fall
+  // back to the first available so we never push to a stale storage (e.g. after
+  // signing into a different project, or after the storage was deleted in OWOX).
+  const applyStorages = useCallback((list: StorageOption[]) => {
+    setStorages(list);
+    const reconciled = reconcileStorageId(store.get().storageId, list);
+    if (reconciled !== store.get().storageId) store.set({ ...store.get(), storageId: reconciled });
+  }, []);
+
   const loadStorages = useCallback(async (): Promise<StorageOption[]> => {
     for (let attempt = 0; attempt < 4; attempt++) {
       try {
         const list = await api<StorageOption[]>("/api/storages");
-        setStorages(list);
-        // Keep the current storage only if it's still in this project; otherwise
-        // fall back to the first available so we never push to a stale storage
-        // (e.g. after signing into a different project).
-        const reconciled = reconcileStorageId(store.get().storageId, list);
-        if (reconciled !== store.get().storageId) store.set({ ...store.get(), storageId: reconciled });
+        applyStorages(list);
         return list;
       } catch {
         await new Promise(r => setTimeout(r, 1200));
       }
     }
     return [];
-  }, []);
+  }, [applyStorages]);
+
+  // User-initiated refresh from the Storage picker. One attempt and the error is
+  // propagated: waiting out four silent retries feels broken, and an empty list
+  // must not be mistaken for "this project has no storages".
+  const refreshStorages = useCallback(async (): Promise<StorageOption[]> => {
+    const list = await api<StorageOption[]>("/api/storages");
+    applyStorages(list);
+    return list;
+  }, [applyStorages]);
 
   useEffect(() => {
     if (!me) { setStorages([]); return; }
@@ -807,6 +820,7 @@ function CanvasInner() {
         storages={storages}
         storageId={graph.storageId}
         onStorageChange={handleStorageChange}
+        onRefreshStorages={refreshStorages}
         onImport={() => setShowImport(true)}
         onImportFromOwox={() => setShowOwoxImport(true)}
         onExport={handleExport}


### PR DESCRIPTION
## The problem

The project's storages are fetched **exactly once**, from an effect keyed on the signed-in user (`Canvas.tsx`). So a storage created in OWOX *after* the API key was added never showed up — the only way to see it was a full page reload. Nothing is cached on our side (`/api/storages` reads OWOX live), so a second request is all that was missing.

## The change

The Storage picker becomes a **custom listbox** instead of a `<select>` — a native select cannot hold an action row. It follows the TopBar's established menu pattern (Export, Push caret): same chip trigger, same backdrop / z-index layering, same hover colours.

- storages listed with a check mark on the current one (`role="option"`, `aria-selected`)
- a **"Refresh the list of storages"** row at the bottom, icon spinning while in flight
- the list **stays open** after a refresh — seeing what arrived is the whole point
- `Escape` closes it

**Feedback is reported in place**, because a successful refresh that changes nothing is otherwise indistinguishable from a broken one:

| Outcome | Shown |
|---|---|
| storages found | `Up to date — 3 storages` |
| none in project | `This project has no storages yet` |
| request failed | `Couldn't reach OWOX — try again` (previous list kept, not blanked) |

## Why refresh doesn't reuse `loadStorages`

`loadStorages` retries 4× with 1.2s pauses and swallows failures into `[]`. Fine for the silent load at sign-in; wrong for a button — it would feel stuck for ~5s, and an empty array would read as "this project has no storages". The shared apply step (including the existing `reconcileStorageId` guard, so a deleted storage still can't be pushed to) is extracted as `applyStorages`; `refreshStorages` does **one** attempt and propagates the error, which is what lets the dropdown tell the two cases apart.

## Verification

`web 443 / server 41 / okf 79` tests green, `pnpm build` clean. Five new tests cover: listing + selecting, refresh keeping the list open with the new storage visible, the empty-project message, the failed-refresh path, and hiding the action when no handler is wired. Two older tests asserted on `role="combobox"` and were rewritten for the new markup.

Verified in the browser on a local build (`pnpm serve`) by @r-obolonskii before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
