### PR TITLE
fix(push): re-create marts that were deleted in OWOX instead of failing their links

### DIFF
--- a/packages/web/src/components/PushConfirmDialog.tsx
+++ b/packages/web/src/components/PushConfirmDialog.tsx
@@ -52,9 +52,10 @@ export function PushConfirmDialog({ projectTitle, storage, counts, onConfirm, on
               <span className="font-semibold">
                 {counts.alreadyPushed} {counts.alreadyPushed === 1 ? "mart is" : "marts are"} already created in this project
               </span>
-              , so {counts.alreadyPushed === 1 ? "it is" : "they are"} skipped. Deleted {counts.alreadyPushed === 1 ? "it" : "them"} in OWOX?
-              Force-push to create {counts.alreadyPushed === 1 ? "it" : "them"} again. Anything still present in OWOX is checked first and left
-              alone, so this can't produce duplicates.
+              , so {counts.alreadyPushed === 1 ? "it is" : "they are"} skipped — unless {counts.alreadyPushed === 1 ? "it was" : "they were"} deleted
+              in OWOX, which Push checks for and repairs by {counts.alreadyPushed === 1 ? "re-creating it" : "re-creating them"}. Want{" "}
+              {counts.alreadyPushed === 1 ? "a mart that is still there" : "marts that are still there"} created again anyway? Force-push — anything
+              still present in OWOX is named and left alone, so this can't produce duplicates.
             </p>
             <button
               onClick={onForcePush}

--- a/packages/web/src/components/PushToast.test.tsx
+++ b/packages/web/src/components/PushToast.test.tsx
@@ -4,7 +4,7 @@ import { PushToast } from "./PushToast";
 import type { PushResult } from "../sync/push";
 
 const result = (over: Partial<PushResult> = {}): PushResult => ({
-  created: 0, updated: 0, failed: 0, blocked: 0,
+  created: 0, updated: 0, failed: 0, blocked: 0, recreated: 0,
   relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [], ...over,
 });
 
@@ -43,6 +43,12 @@ describe("PushToast", () => {
   it("counts failed marts and failed links apart", () => {
     render(<PushToast result={result({ created: 10, failed: 1, relationshipsFailed: 14, errors: ["boom"] })} onClose={() => {}} />);
     expect(screen.getByText(/1 mart failed, 14 links failed/)).toBeTruthy();
+  });
+
+  it("explains why a mart got a new OWOX id", () => {
+    render(<PushToast result={result({ created: 2, recreated: 2, relationshipsCreated: 1 })} onClose={() => {}} />);
+    expect(screen.getByText("Push complete")).toBeTruthy();
+    expect(screen.getByText(/2 marts were marked as created here but no longer existed in OWOX/i)).toBeTruthy();
   });
 
   it("notes links pushed without join keys", () => {

--- a/packages/web/src/components/PushToast.tsx
+++ b/packages/web/src/components/PushToast.tsx
@@ -9,6 +9,7 @@ import type { PushResult } from "../sync/push";
 export function PushToast({ result, onClose }: { result: PushResult; onClose: () => void }) {
   const blocked = result.blocked ?? 0;
   const keyless = result.relationshipsWithoutKeys ?? 0;
+  const recreated = result.recreated ?? 0;
   const failed = result.failed + result.relationshipsFailed;
   const pushedNothing = result.created === 0 && result.relationshipsCreated === 0;
 
@@ -37,6 +38,12 @@ export function PushToast({ result, onClose }: { result: PushResult; onClose: ()
           {title}
           {parts.length > 0 && (
             <div className="font-normal text-slate-500 text-[12px] mt-0.5">{parts.join(", ")}</div>
+          )}
+          {recreated > 0 && (
+            <div className="font-normal text-[12px] mt-1 text-slate-500 leading-snug">
+              {recreated} {recreated === 1 ? "mart was" : "marts were"} marked as created here but no longer existed in OWOX
+              (deleted there), so {recreated === 1 ? "it was" : "they were"} created again with a new OWOX id.
+            </div>
           )}
           {keyless > 0 && (
             <div className="font-normal text-[12px] mt-1 text-slate-500 leading-snug">

--- a/packages/web/src/components/canvas/Canvas.tsx
+++ b/packages/web/src/components/canvas/Canvas.tsx
@@ -761,7 +761,7 @@ function CanvasInner() {
       const result = await pushModel(store, undefined, storageType, opts);
       setPushResult(result);
     } catch (e) {
-      setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [(e as Error).message] });
+      setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, recreated: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [(e as Error).message] });
     } finally {
       setPushing(false);
     }
@@ -940,7 +940,7 @@ function CanvasInner() {
             const list = await loadStorages();
             if (mode === "push") {
               if (list.length === 0) {
-                setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
+                setPushResult({ created: 0, updated: 0, failed: 0, blocked: 0, recreated: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: ["Couldn't load your OWOX storages — please try Push again."] });
                 return;
               }
               await runPush(list);

--- a/packages/web/src/sync/push.ts
+++ b/packages/web/src/sync/push.ts
@@ -12,6 +12,9 @@ export interface PushResult {
   /** Marts a forced push held back because they are still in OWOX. Not a failure
    *  — nothing broke, we refused to create a duplicate. */
   blocked: number;
+  /** Subset of `created`: marts that looked created here but had been deleted in
+   *  OWOX, so this push re-created them (and gave them a new OWOX id). */
+  recreated: number;
   relationshipsCreated: number;
   relationshipsFailed: number;
   /** Links created as "Join not configured" in OWOX because the canvas edge has no
@@ -26,6 +29,10 @@ export interface PushResult {
 // skipped. An imported (existing) edge is skipped only when both endpoints stay.
 // alreadyPushed reports how many marts the skip swallows, so the dialog can say
 // why a push would send nothing and offer a force push instead.
+//
+// Deliberately local and synchronous: it cannot know that a mart was deleted in
+// OWOX (pushModel finds that out with a listing and re-creates it), so its counts
+// are a floor, not a promise. The dialog's wording accounts for that.
 export function pushPreview(graph: ModelGraph, storageId: string | null): { marts: number; relationships: number; alreadyPushed: number } {
   const liveHere = (n: ModelNode) => n.status === "created" && n.owoxStorageId === storageId;
   const skipped = new Set(graph.nodes.filter(liveHere).map(n => n.key));
@@ -53,33 +60,45 @@ function schemaDiscriminator(storageType: string): string {
 }
 
 export interface PushOptions {
-  /** Re-create marts that are already live in the active storage. For the case
-   *  where the user deleted them inside OWOX and wants the same model back: the
-   *  stored owoxId points at a mart that no longer exists, so skipping it would
-   *  silently push nothing. Marts that are still in OWOX are held back rather
-   *  than duplicated — see findBlockedMarts. */
+  /** Re-create marts that are already live in the active storage — the "I want this
+   *  model in OWOX again" hammer. A normal push already repairs marts that were
+   *  deleted in OWOX (see the ghosts half of reconcileWithOwox), so force is for
+   *  the rest: re-creating marts that ARE still there. Anything still present is
+   *  held back rather than duplicated. */
   force?: boolean;
 }
 
-/** What a forced push must not touch: marts whose stored owoxId is still listed
- *  in OWOX. Creating those again would leave the project with two copies and no
- *  way to tell them apart, so we hold them back and say which status they're in.
- *  Throws if the listing can't be read — guessing would risk the duplicates this
- *  check exists to prevent. */
-async function findBlockedMarts(store: ModelStore, api: Api, storageId: string): Promise<Map<string, string | undefined>> {
+/** Reconciles what the canvas believes about OWOX against what OWOX actually has.
+ *  Two mirror-image answers come out of the same listing:
+ *
+ *  - `blocked` — the mart's stored owoxId IS still there. A forced push must not
+ *    re-create those: the project would end up with two copies and no way to tell
+ *    them apart. Carries each one's OWOX status so we can name it.
+ *  - `ghosts` — the mart is marked created here but its owoxId is GONE (deleted in
+ *    OWOX, or the model was imported and then cleaned up there). A normal push used
+ *    to skip these on local state alone and then fail the relationship POST with a
+ *    404 about a mart that no longer exists — or, for a fully imported model, do
+ *    nothing at all and report success. They are re-created instead.
+ *
+ *  Throws if the listing can't be read; each caller decides what that means. */
+async function reconcileWithOwox(
+  store: ModelStore, api: Api, storageId: string,
+): Promise<{ blocked: Map<string, string | undefined>; ghosts: Set<string> }> {
   const live = await api<Array<{ id: string; title?: string; status?: string }>>("/api/data-marts");
   if (!Array.isArray(live)) throw new Error("unexpected data mart listing");
   const statusById = new Map(live.map(m => [m.id, m.status]));
   const blocked = new Map<string, string | undefined>();
+  const ghosts = new Set<string>();
   for (const n of store.get().nodes) {
     if (n.status !== "created" || n.owoxStorageId !== storageId || !n.owoxId) continue;
     if (statusById.has(n.owoxId)) blocked.set(n.key, statusById.get(n.owoxId));
+    else ghosts.add(n.key);
   }
-  return blocked;
+  return { blocked, ghosts };
 }
 
 export async function pushModel(store: ModelStore, api: Api = defaultApi, storageType?: string, opts: PushOptions = {}): Promise<PushResult> {
-  const res: PushResult = { created: 0, updated: 0, failed: 0, blocked: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [] };
+  const res: PushResult = { created: 0, updated: 0, failed: 0, blocked: 0, recreated: 0, relationshipsCreated: 0, relationshipsFailed: 0, relationshipsWithoutKeys: 0, errors: [] };
 
   const storageId = store.get().storageId;
   if (!storageId) {
@@ -90,27 +109,37 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
     return res;
   }
 
-  // ── 0. A forced push first asks OWOX what is actually there ─────────────────
-  // The premise of a forced push is "I deleted these in OWOX". Verify it before
-  // creating anything: a mart still listed there would become a duplicate, which
-  // nobody can untangle afterwards. Blocked marts keep their green dot — it is
-  // honest, they really are in OWOX — and are reported instead of pushed.
+  // ── 0. Ask OWOX what is actually there before trusting our own bookkeeping ──
+  // A forced push says "I deleted these in OWOX" — verify it, because a mart still
+  // listed there would become a duplicate nobody can untangle afterwards. A normal
+  // push needs the mirror answer: a mart we think we created but which is gone must
+  // be re-created, or its relationships fail against a dead id.
   const blockedKeys = new Set<string>();
-  if (opts.force) {
-    let blocked: Map<string, string | undefined>;
+  const ghostKeys = new Set<string>();
+  {
+    let recon: { blocked: Map<string, string | undefined>; ghosts: Set<string> } | null = null;
     try {
-      blocked = await findBlockedMarts(store, api, storageId);
+      recon = await reconcileWithOwox(store, api, storageId);
     } catch (e) {
-      res.errors.push(`Could not check which marts still exist in OWOX (${(e as Error).message}) — nothing was pushed.`);
-      return res;
+      // A forced push cannot continue on a guess — duplicates are unrecoverable.
+      if (opts.force) {
+        res.errors.push(`Could not check which marts still exist in OWOX (${(e as Error).message}) — nothing was pushed.`);
+        return res;
+      }
+      // A normal push falls back to the old local-state-only skip: without the
+      // listing, re-creating would risk exactly the duplicates we guard against.
     }
-    for (const [key, owoxStatus] of blocked) {
-      const title = store.get().nodes.find(n => n.key === key)?.title ?? key;
-      blockedKeys.add(key);
-      res.blocked++;
-      res.errors.push(
-        `"${title}" still exists in OWOX${owoxStatus ? ` (${owoxStatus})` : ""} — delete it there first, otherwise this would create a duplicate.`,
-      );
+    if (opts.force) {
+      for (const [key, owoxStatus] of recon?.blocked ?? []) {
+        const title = store.get().nodes.find(n => n.key === key)?.title ?? key;
+        blockedKeys.add(key);
+        res.blocked++;
+        res.errors.push(
+          `"${title}" still exists in OWOX${owoxStatus ? ` (${owoxStatus})` : ""} — delete it there first, otherwise this would create a duplicate.`,
+        );
+      }
+    } else {
+      for (const key of recon?.ghosts ?? []) ghostKeys.add(key);
     }
   }
 
@@ -137,10 +166,11 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
   // it must be recreated here rather than silently skipped. A forced push skips
   // only what step 0 found still living in OWOX; everything else is created again
   // (and so are its relationships, since the edge skip below keys off this set).
+  // Ghosts — created here, but no longer in OWOX — are likewise NOT skipped.
   const skippedKeys = new Set<string>();
   for (const n of store.get().nodes) {
     if (blockedKeys.has(n.key)) { skippedKeys.add(n.key); continue; }
-    if (!opts.force && n.status === "created" && n.owoxStorageId === storageId) { skippedKeys.add(n.key); continue; }
+    if (!opts.force && n.status === "created" && n.owoxStorageId === storageId && !ghostKeys.has(n.key)) { skippedKeys.add(n.key); continue; }
     store.updateNode(n.key, { status: "creating", error: null });
     try {
       // Create a draft with just { title, storageId } — confirmed to always 201.
@@ -187,6 +217,9 @@ export async function pushModel(store: ModelStore, api: Api = defaultApi, storag
       }
       store.updateNode(n.key, { status: "created", owoxId: out.id, owoxStorageId: storageId, createdAt: new Date().toISOString() });
       res.created++;
+      // Counted only once it actually landed, so a failed re-create isn't reported
+      // as a repair. Surfaced in the toast: the mart quietly changed its OWOX id.
+      if (ghostKeys.has(n.key)) res.recreated++;
     } catch (e) {
       const msg = (e as Error).message;
       store.updateNode(n.key, { status: "error", error: msg });

--- a/packages/web/test/push.test.ts
+++ b/packages/web/test/push.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { pushModel, pushPreview } from "../src/sync/push";
 import { createModelStore } from "../src/state/model";
-import type { ModelGraph } from "@mc/okf";
+import type { ModelGraph, ModelEdge } from "@mc/okf";
 
 describe("pushPreview", () => {
   const mk = (over: Partial<ModelGraph>): ModelGraph => ({ storageId: "st_1", nodes: [], edges: [], ...over });
@@ -352,13 +352,19 @@ describe("pushModel", () => {
     expect(res.errors[0]).toMatch(/could not check|HTTP 500/i);
   });
 
-  it("does not list OWOX marts on a normal push — the skip needs no lookup", async () => {
+  // A normal push now lists the project's marts too: the local "already created"
+  // flag is not evidence that the mart still exists (it can be deleted in OWOX).
+  it("lists OWOX marts on a normal push to verify the ids it holds", async () => {
     const s = createModelStore({ storageId: "stor_1" });
     s.addNode({ x: 0, y: 0 });
     const calls: string[] = [];
-    const apiMock = vi.fn(async (path: string, init?: any) => { calls.push(`${init?.method ?? "GET"} ${path}`); return { id: "owox_a" }; });
+    const apiMock = vi.fn(async (path: string, init?: any) => {
+      calls.push(`${init?.method ?? "GET"} ${path}`);
+      if (path === "/api/data-marts" && (init?.method ?? "GET") === "GET") return [];
+      return { id: "owox_a" };
+    });
     await pushModel(s, apiMock as any);
-    expect(calls).not.toContain("GET /api/data-marts");
+    expect(calls).toContain("GET /api/data-marts");
   });
 
   it("uses an underscore identifier (not a hyphenated slug) for targetAlias", async () => {
@@ -461,6 +467,89 @@ describe("pushModel", () => {
     expect(res.relationshipsCreated).toBe(0);
     expect(res.relationshipsFailed).toBe(1);
     expect(res.errors.some(e => /both marts must be created first/.test(e))).toBe(true);
+  });
+
+  // ── ghosts: marts we think we created, but OWOX no longer has ────────────────
+  // Reported case: a model imported from OWOX (or pushed earlier), then deleted in
+  // OWOX. The canvas kept the stale owoxId, the skip fired on local state alone,
+  // and the relationship POST 404'd against a mart that no longer existed.
+  describe("a mart deleted in OWOX", () => {
+    // live: what GET /api/data-marts returns; every other call returns a fresh id.
+    const apiWith = (live: Array<{ id: string; title?: string; status?: string }>, calls: string[] = [], bodies: any[] = []) =>
+      vi.fn(async (path: string, init?: any) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${path}`);
+        if (path === "/api/data-marts" && method === "GET") return live;
+        if (init?.body) bodies.push({ path, body: JSON.parse(init.body) });
+        return { id: "fresh_id" };
+      });
+
+    const twoMarts = (edge: Partial<ModelEdge> = {}) => {
+      const s = createModelStore({ storageId: "stor_1" });
+      s.set({
+        storageId: "stor_1",
+        nodes: [
+          { key: "n1", title: "A", inputSource: "SQL", schema: [{ name: "b_id", type: "STRING", pk: false }], position: { x: 0, y: 0 }, status: "created", owoxId: "ghost_a", owoxStorageId: "stor_1" },
+          { key: "n2", title: "B", inputSource: "SQL", schema: [{ name: "id", type: "STRING", pk: true }], position: { x: 100, y: 0 }, status: "created", owoxId: "ghost_b", owoxStorageId: "stor_1" },
+        ],
+        edges: [{ id: "e1", from: "n1", to: "n2", keys: [{ left: "b_id", right: "id" }], bidirectional: false, ...edge }],
+      });
+      return s;
+    };
+
+    it("re-creates it instead of skipping, and reports the repair", async () => {
+      const s = twoMarts();
+      const res = await pushModel(s, apiWith([]) as any); // OWOX has neither mart
+      expect(res.created).toBe(2);
+      expect(res.recreated).toBe(2);
+      expect(res.failed).toBe(0);
+      expect(s.get().nodes.map(n => n.owoxId)).toEqual(["fresh_id", "fresh_id"]);
+    });
+
+    it("points the relationship at the NEW id — the reported 404", async () => {
+      const s = twoMarts();
+      const calls: string[] = [];
+      const res = await pushModel(s, apiWith([], calls) as any);
+      expect(calls).toContain("POST /api/data-marts/fresh_id/relationships");
+      expect(calls).not.toContain("POST /api/data-marts/ghost_a/relationships");
+      expect(res.relationshipsCreated).toBe(1);
+      expect(res.errors).toEqual([]);
+    });
+
+    it("pushes an imported edge too, instead of reporting a silent success", async () => {
+      // Both endpoints gone: the old skip made this push a no-op that still said
+      // "Push complete" — nothing in OWOX, no error, nothing to act on.
+      const s = twoMarts({ existing: true });
+      const res = await pushModel(s, apiWith([]) as any);
+      expect(res.created).toBe(2);
+      expect(res.relationshipsCreated).toBe(1);
+    });
+
+    it("leaves a mart that is still there alone", async () => {
+      const s = twoMarts();
+      const calls: string[] = [];
+      const bodies: any[] = [];
+      const res = await pushModel(s, apiWith([{ id: "ghost_a", title: "A" }], calls, bodies) as any);
+      expect(res.created).toBe(1);          // only B was missing
+      expect(res.recreated).toBe(1);
+      expect(bodies.filter(b => b.path === "/api/data-marts").map(b => b.body.title)).toEqual(["B"]);
+      expect(s.get().nodes[0].owoxId).toBe("ghost_a"); // A keeps its id
+    });
+
+    it("keeps skipping when the listing can't be read — a guess would duplicate", async () => {
+      const s = twoMarts();
+      const calls: string[] = [];
+      const apiMock = vi.fn(async (path: string, init?: any) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${path}`);
+        if (path === "/api/data-marts" && method === "GET") throw new Error("HTTP 500");
+        return { id: "fresh_id" };
+      });
+      const res = await pushModel(s, apiMock as any);
+      expect(calls).not.toContain("POST /api/data-marts");
+      expect(res.created).toBe(0);
+      expect(res.recreated).toBe(0);
+    });
   });
 
   // Defence in depth for models saved before types were normalised on import:


### PR DESCRIPTION
## The report

A model was imported from an OWOX project, then its marts were deleted in ODM. Pushing it again created **nothing** and failed the relationship with:

```
Link A → B: OWOX POST /api/data-marts/f468fcd7-…/relationships
-> 404 Data Mart with id f468fcd7-… and projectId 6041dd6a… not found
```

Confirmed against the live API — the id the canvas was holding really was gone:

```
GET /api/data-marts/f468fcd7-4310-48ca-afa6-b2dc5ce174ba → 404
marts in project: 10 · target listed: false · marts titled A/B: none
```

## Why

The skip in push step 2 trusted local bookkeeping alone — `status === "created"` plus a matching `owoxStorageId` meant "already in OWOX, skip" — and step 3 then POSTed the relationship against that dead id.

For a **fully imported** model it was worse than an error: imported edges (`existing: true`) are skipped when both endpoints are skipped, so the push was a **silent no-op that reported success**. Nothing in OWOX, no error, nothing to act on.

## The fix

`findBlockedMarts` becomes `reconcileWithOwox`, answering both halves from the one listing it already fetched:

| | meaning | behaviour |
|---|---|---|
| `blocked` | the stored `owoxId` **is** still in OWOX | a forced push must not duplicate it (unchanged) |
| `ghosts` | the stored `owoxId` is **gone** | a normal push re-creates the mart |

Failure handling is **deliberately asymmetric**:

- **force** still aborts when the listing can't be read — a duplicate is unrecoverable, so never guess.
- **normal** falls back to the old local-state-only skip. Without the listing, re-creating risks exactly those duplicates; doing nothing is the safe default.

`PushResult` gains `recreated` (a subset of `created`, counted only once the mart actually landed, so a failed re-create isn't reported as a repair) and the toast explains why a mart suddenly carries a new OWOX id — otherwise that looks like magic.

## Copy this change made untrue

The confirm dialog's amber block claimed already-created marts "are skipped", full stop. It now says they're skipped *unless they were deleted in OWOX, which Push checks for and repairs*, and frames force-push as the tool for marts that **are** still there.

`pushPreview` stays local and synchronous — it cannot know about a deletion in OWOX, so its counts are now documented as a floor (the push may create more than promised) and the dialog wording accounts for that. Making it async is a separate change.

## Verification

Live end-to-end with the **real `pushModel`** against `app.owox.com`, reproducing the exact reported sequence:

```
first push:      created 2, link 1
deleted in OWOX: 24ea47c1… 200 · e192a571… 200     ← what the user did in ODM
second push:     created 2, recreated 2, links 1, errors []
live graph:      1 relationship on the FRESH ids, join key b_id = id
cleanup:         both new marts deleted (200), 0 leftovers
```

Worth recording: the **first run of that harness failed for its own reason** — it called OWOX directly, which returns `{items, nextOffset}`, while `push.ts` talks to our BFF, which flattens the listing into an array (`client.listDataMarts`). The harness was testing a shape production never sees. Independent proof the array shape is real in production: force-push works for the user, and it reads the same listing through the same code.

`web 449 / server 41 / okf 79` tests green, build clean. Five new tests cover: re-creation + repair count, the relationship pointing at the new id (the reported 404), an imported edge being pushed instead of the silent no-op, a still-present mart being left alone, and a failed listing not producing duplicates. One older test pinned the behaviour this PR changes ("does not list OWOX marts on a normal push") and was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
